### PR TITLE
Allow 'bind' in config to specify bind address

### DIFF
--- a/app.go
+++ b/app.go
@@ -404,6 +404,10 @@ func Serve() {
 	http.Handle("/", r)
 
 	// Start web application server
+	var bindAddress = app.cfg.Server.Bind
+	if bindAddress == "" {
+		bindAddress = "localhost"
+	}
 	if app.cfg.IsSecureStandalone() {
 		log.Info("Serving redirects on http://localhost:80")
 		go func() {
@@ -413,13 +417,14 @@ func Serve() {
 			log.Error("Unable to start redirect server: %v", err)
 		}()
 
-		log.Info("Serving on https://localhost:443")
+		log.Info("Serving on %s:443", bindAddress)
 		log.Info("---")
-		err = http.ListenAndServeTLS(":443", app.cfg.Server.TLSCertPath, app.cfg.Server.TLSKeyPath, nil)
+		err = http.ListenAndServeTLS(
+			fmt.Sprintf("%s:443", bindAddress), app.cfg.Server.TLSCertPath, app.cfg.Server.TLSKeyPath, nil)
 	} else {
-		log.Info("Serving on http://localhost:%d\n", app.cfg.Server.Port)
+		log.Info("Serving on http://%s:%d\n", bindAddress, app.cfg.Server.Port)
 		log.Info("---")
-		err = http.ListenAndServe(fmt.Sprintf(":%d", app.cfg.Server.Port), nil)
+		err = http.ListenAndServe(fmt.Sprintf("%s:%d", bindAddress, app.cfg.Server.Port), nil)
 	}
 	if err != nil {
 		log.Error("Unable to start: %v", err)

--- a/app.go
+++ b/app.go
@@ -418,7 +418,7 @@ func Serve() {
 			log.Error("Unable to start redirect server: %v", err)
 		}()
 
-		log.Info("Serving on %s:443", bindAddress)
+		log.Info("Serving on https://%s:443", bindAddress)
 		log.Info("---")
 		err = http.ListenAndServeTLS(
 			fmt.Sprintf("%s:443", bindAddress), app.cfg.Server.TLSCertPath, app.cfg.Server.TLSKeyPath, nil)

--- a/app.go
+++ b/app.go
@@ -409,11 +409,12 @@ func Serve() {
 		bindAddress = "localhost"
 	}
 	if app.cfg.IsSecureStandalone() {
-		log.Info("Serving redirects on http://localhost:80")
+		log.Info("Serving redirects on http://%s:80", bindAddress)
 		go func() {
-			err = http.ListenAndServe(":80", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				http.Redirect(w, r, app.cfg.App.Host, http.StatusMovedPermanently)
-			}))
+			err = http.ListenAndServe(
+				fmt.Sprintf("%s:80", bindAddress), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					http.Redirect(w, r, app.cfg.App.Host, http.StatusMovedPermanently)
+				}))
 			log.Error("Unable to start redirect server: %v", err)
 		}()
 

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ type (
 	ServerCfg struct {
 		HiddenHost string `ini:"hidden_host"`
 		Port       int    `ini:"port"`
+		Bind       string `ini:"bind"`
 
 		TLSCertPath string `ini:"tls_cert_path"`
 		TLSKeyPath  string `ini:"tls_key_path"`
@@ -60,6 +61,7 @@ func New() *Config {
 	return &Config{
 		Server: ServerCfg{
 			Port: 8080,
+			Bind: "localhost", /* IPV6 support when not using localhost? */
 		},
 		Database: DatabaseCfg{
 			Type: "mysql",


### PR DESCRIPTION
Minimal changes, definitely WIP

To resolve:
- how to support dualstack when not using localhost?
- net/http package uses string, mentions IP address instead of bind,
  need info.

For issue #5 