### PR TITLE
Add openssl and root anchors for federation queries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir /stage && \
 
 FROM alpine:3.8
 
+RUN apk add --no-cache openssl ca-certificates
 COPY --from=build --chown=daemon:daemon /stage /go
 
 WORKDIR /go


### PR DESCRIPTION
The lack of trust anchors was preventing outgoing https queries.

The lack of openssl binary was preventing the generation of actor key and cert. In the long term, I think go has proper primitives to access libssl instead of running openssl system calls.