### PR TITLE
Fix the Docker build when installing go-sqlite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.11.2-alpine3.8 as build
 
-RUN apk add --update nodejs nodejs-npm make git
+RUN apk add --update nodejs nodejs-npm make g++ git sqlite-dev
 RUN npm install -g less
 RUN npm install -g less-plugin-clean-css
 


### PR DESCRIPTION
Go-SQLite requires sqlite library headers and gcc.