### PR TITLE
use font-display:optional to optimize web font loading

### DIFF
--- a/less/fonts.less
+++ b/less/fonts.less
@@ -3,6 +3,7 @@
 	font-family: 'Open Sans';
 	font-style: normal;
 	font-weight: 400;
+  font-display: optional;
 	src: url('/fonts/open-sans-v13-latin-regular.eot'); /* IE9 Compat Modes */
 	src: local('Open Sans'), local('OpenSans'),
 	   url('/fonts/open-sans-v13-latin-regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -16,6 +17,7 @@
 	font-family: 'Open Sans';
 	font-style: normal;
 	font-weight: 700;
+  font-display: optional;
 	src: url('/fonts/open-sans-v13-latin-700.eot'); /* IE9 Compat Modes */
 	src: local('Open Sans Bold'), local('OpenSans-Bold'),
 	   url('/fonts/open-sans-v13-latin-700.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -29,6 +31,7 @@
 	font-family: 'Lora';
 	font-style: normal;
 	font-weight: 400;
+  font-display: optional;
 	src: url('/fonts/Lora-Regular.eot'); /* IE9 Compat Modes */
 	src: local('Lora'), local('Lora-Regular'),
 	   url('/fonts/Lora-Regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -41,6 +44,7 @@
 	font-family: 'Lora';
 	font-style: normal;
 	font-weight: 700;
+  font-display: optional;
 	src: url('/fonts/Lora-Bold.eot'); /* IE9 Compat Modes */
 	src: local('Lora Bold'), local('Lora-Bold'),
 	   url('/fonts/Lora-Bold.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -52,6 +56,7 @@
   font-family: 'Lora';
   font-style: italic;
   font-weight: 400;
+  font-display: optional;
   src: url('/fonts/Lora-Italic.eot'); /* IE9 Compat Modes */
   src: local('Lora Italic'), local('Lora-Italic'),
        url('/fonts/Lora-Italic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */


### PR DESCRIPTION
Adds `font-display: optional` to all `@font-face` entries. This optimizes the font loading by allowing the browser to hide the content only for a very short time before either setting the webfont (if loaded by then) or using a default font. It even allows the browser to not load web fonts at all on very slow connections. See the [MDN article about font-display](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) for more information.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
