### PR TITLE
Deploy the app in the proper dir for dependency management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,24 @@
+# Build image
 FROM golang:1.11.2-alpine3.8 as build
 
 RUN apk add --update nodejs nodejs-npm make g++ git sqlite-dev
-RUN npm install -g less
-RUN npm install -g less-plugin-clean-css
+RUN npm install -g less less-plugin-clean-css
 
-WORKDIR /go/src/app
+RUN mkdir -p /go/src/github.com/writeas/writefreely
+WORKDIR /go/src/github.com/writeas/writefreely
 COPY . .
 
-RUN make assets
-RUN make install
-RUN make ui
-RUN make deps
-
+RUN make build \
+ && make ui
 RUN mkdir /stage && \
     cp -R /go/bin \
-       /go/src/app/templates \
-       /go/src/app/static \
-       /go/src/app/pages \
-       /go/src/app/keys \
+      /go/src/github.com/writeas/writefreely/templates \
+      /go/src/github.com/writeas/writefreely/static \
+      /go/src/github.com/writeas/writefreely/pages \
+      /go/src/github.com/writeas/writefreely/keys \
       /stage
 
+# Final image
 FROM alpine:3.8
 
 RUN apk add --no-cache openssl ca-certificates


### PR DESCRIPTION
If anyone could please test this, it is meant to close #57. The idea is to copy the source in the right github.com/writeas folder so that dependency management use it instead of re-downloading it from Github, which omits the go-bindata generated file.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
