### PR TITLE
Support configuring resource directories

### DIFF
--- a/app.go
+++ b/app.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"syscall"
@@ -41,7 +42,7 @@ import (
 )
 
 const (
-	staticDir       = "static/"
+	staticDir       = "static"
 	assumedTitleLen = 80
 	postsPerPage    = 10
 
@@ -336,7 +337,7 @@ func Serve() {
 	isSingleUser = app.cfg.App.SingleUser
 	app.cfg.Server.Dev = *debugPtr
 
-	initTemplates()
+	initTemplates(app.cfg)
 
 	// Load keys
 	log.Info("Loading encryption keys...")
@@ -395,7 +396,7 @@ func Serve() {
 	}
 
 	// Handle static files
-	fs := http.FileServer(http.Dir(staticDir))
+	fs := http.FileServer(http.Dir(filepath.Join(app.cfg.Server.StaticParentDir, staticDir)))
 	shttp.Handle("/", fs)
 	r.PathPrefix("/").Handler(fs)
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,11 @@ type (
 		TLSCertPath string `ini:"tls_cert_path"`
 		TLSKeyPath  string `ini:"tls_key_path"`
 
+		TemplatesParentDir string `ini:"templates_parent_dir"`
+		StaticParentDir    string `ini:"static_parent_dir"`
+		PagesParentDir     string `ini:"pages_parent_dir"`
+		KeysParentDir      string `ini:"keys_parent_dir"`
+
 		Dev bool `ini:"-"`
 	}
 

--- a/keys.go
+++ b/keys.go
@@ -38,16 +38,28 @@ func initKeys(app *app) error {
 	var err error
 	app.keys = &keychain{}
 
+	emailKeyPath = filepath.Join(app.cfg.Server.KeysParentDir, emailKeyPath)
+	if debugging {
+		log.Info("  %s", emailKeyPath)
+	}
 	app.keys.emailKey, err = ioutil.ReadFile(emailKeyPath)
 	if err != nil {
 		return err
 	}
 
+	cookieAuthKeyPath = filepath.Join(app.cfg.Server.KeysParentDir, cookieAuthKeyPath)
+	if debugging {
+		log.Info("  %s", cookieAuthKeyPath)
+	}
 	app.keys.cookieAuthKey, err = ioutil.ReadFile(cookieAuthKeyPath)
 	if err != nil {
 		return err
 	}
 
+	cookieKeyPath = filepath.Join(app.cfg.Server.KeysParentDir, cookieKeyPath)
+	if debugging {
+		log.Info("  %s", cookieKeyPath)
+	}
 	app.keys.cookieKey, err = ioutil.ReadFile(cookieKeyPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds new configuration values that specify the parent directory of application resources:

- `templates_parent_dir`
- `static_parent_dir`
- `pages_parent_dir`
- `keys_parent_dir`

For any values not specified, the application will default to the current directory.

This closes [T560](https://phabricator.write.as/T560)