### PR TITLE
Changes to app.go to ensure writefreely works with OpenBSD

### DIFF
--- a/app.go
+++ b/app.go
@@ -15,6 +15,7 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -604,7 +605,7 @@ func adminInitDatabase(app *app) error {
 		schemaFileName = "sqlite.sql"
 	}
 
-	schema, err := Asset(schemaFileName)
+	schema, err := ioutil.ReadFile(schemaFileName)
 	if err != nil {
 		return fmt.Errorf("Unable to load schema file: %v", err)
 	}


### PR DESCRIPTION
OpenBSD doesn't seem to want to play with "Asset" in app.go. I've reverted the changes from a previous commit and this works, but I'm not a go developer so I don't know whether this is the right thing to do.

If it is, then great. If not, happy to try things out.

---

- [X] I have signed the [CLA](https://phabricator.write.as/L1)
