### PR TITLE
Resolve an edge case where last language has error

### DIFF
--- a/templates/include/post-render.tmpl
+++ b/templates/include/post-render.tmpl
@@ -22,8 +22,12 @@
         var sc = document.createElement('script');
         sc.src = uri;
         sc.async = false; // critical?
+	// Set callback on last script
         if (uris.indexOf(uri) == uris.length-1) {
-          sc.onload = callback;
+	  // Set callback regardless
+	  // so we're sure it will run if last element had error
+	  // (we only know after loading, so we've had load time already)
+          sc.onload  = callback; sc.onerror = callback;
         }
         document.head.appendChild(sc);
       });


### PR DESCRIPTION
If there are multiple language blocks on a page, we set the
onload on the last one to load all highlighting at once.

If the last language block has an error, the onload would
never fire and thus all blocks would not be highlighted.

The simplest resolution is to fire the callback regardless. We've
already loaded everything so running the callback is not causing any
performance hit which is relevant I think.
