### PR TITLE
Support new commentsEnabled property

### DIFF
--- a/posts.go
+++ b/posts.go
@@ -1021,7 +1021,10 @@ func fetchPost(app *app, w http.ResponseWriter, r *http.Request) error {
 
 		p.Collection = &CollectionObj{Collection: *coll}
 		po := p.ActivityObject()
-		po.Context = []interface{}{activitystreams.Namespace}
+		po.Context = []interface{}{
+			activitystreams.Namespace,
+			activitystreams.Extensions,
+		}
 		return impart.RenderActivityJSON(w, po, http.StatusOK)
 	}
 
@@ -1091,6 +1094,9 @@ func (p *PublicPost) ActivityObject() *activitystreams.Object {
 			})
 		}
 	}
+
+	o.CommentsEnabled = false
+
 	return o
 }
 
@@ -1300,7 +1306,10 @@ func viewCollectionPost(app *app, w http.ResponseWriter, r *http.Request) error 
 	} else if strings.Contains(r.Header.Get("Accept"), "application/activity+json") {
 		p.extractData()
 		ap := p.ActivityObject()
-		ap.Context = []interface{}{activitystreams.Namespace}
+		ap.Context = []interface{}{
+			activitystreams.Namespace,
+			activitystreams.Extensions,
+		}
 		return impart.RenderActivityJSON(w, ap, http.StatusOK)
 	} else {
 		p.extractData()


### PR DESCRIPTION
This is a field previously supported by PeerTube, and just recently added on PixelFed, that should inform other ActivityPub services whether or not comments / replies are enabled on any given post.

WriteFreely doesn't support comments today, so this will always be `false`. When we support them in the future, this value will reflect the author's choice to accept replies or not.