### PR TITLE
Fix the build in Docker after enabling go modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 # Build image
-FROM golang:1.11.2-alpine3.8 as build
+FROM golang:1.12-alpine as build
 
 RUN apk add --update nodejs nodejs-npm make g++ git sqlite-dev
 RUN npm install -g less less-plugin-clean-css
+RUN go get -u github.com/jteeuwen/go-bindata/...
 
 RUN mkdir -p /go/src/github.com/writeas/writefreely
 WORKDIR /go/src/github.com/writeas/writefreely
 COPY . .
 
+ENV GO111MODULE=on
 RUN make build \
  && make ui
 RUN mkdir /stage && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN mkdir /stage && \
       /go/src/github.com/writeas/writefreely/static \
       /go/src/github.com/writeas/writefreely/pages \
       /go/src/github.com/writeas/writefreely/keys \
+      /go/src/github.com/writeas/writefreely/cmd \
       /stage
 
 # Final image
@@ -31,4 +32,4 @@ VOLUME /go/keys
 EXPOSE 8080
 USER daemon
 
-CMD ["bin/writefreely"]
+ENTRYPOINT ["cmd/writefreely/writefreely"]


### PR DESCRIPTION
This fixes #93 in the context of a Docker build.

Enabling go modules requires that GO111MODULE is set, so
we set it as an environment variable in the Dockerfile.

Also, go-bindata is meant to be installed globally, so we
force the install before enabling Go modules. Also, we update
Go to 1.12 to fix a couple module builds.
---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
