### PR TITLE
Tweak Makefile for MacOS

### DIFF
--- a/less/Makefile
+++ b/less/Makefile
@@ -1,5 +1,7 @@
 ifeq ($(shell which lessc),/usr/bin/lessc)
 	LESSC=/usr/bin/lessc
+else ifeq ($(shell which lessc),/usr/local/bin/lessc)
+	LESSC=/usr/local/bin/lessc
 else
 	LESSC=node_modules/.bin/lessc
 endif


### PR DESCRIPTION
On my MacOS machine, global node binaries like `lessc` are stored in `/usr/local/bin/`. The current Makefile only checks for `/usr/bin/` and this rectifies that error. There is probably a better way to just run `which lessc` and then use that path, defaulting to `node_modules` if that path doesn't exist, but as this is my first contribution to the project I wanted to stick with what was already there, stylistically.

---

- [X] I have signed the [CLA](https://phabricator.write.as/L1)
