### PR TITLE
Strip newlines from AP Article object HTML output

### DIFF
--- a/less/Makefile
+++ b/less/Makefile
@@ -1,5 +1,7 @@
 ifeq ($(shell which lessc),/usr/bin/lessc)
 	LESSC=/usr/bin/lessc
+else ifeq ($(shell which lessc),/usr/local/bin/lessc)
+	LESSC=/usr/local/bin/lessc
 else
 	LESSC=node_modules/.bin/lessc
 endif

--- a/posts.go
+++ b/posts.go
@@ -1057,6 +1057,8 @@ func (p *PublicPost) CanonicalURL() string {
 	return p.Collection.CanonicalURL() + p.Slug.String
 }
 
+var newlineRegex = regexp.MustCompile(`\r?\n`)
+
 func (p *PublicPost) ActivityObject() *activitystreams.Object {
 	o := activitystreams.NewArticleObject()
 	o.ID = p.Collection.FederatedAPIBase() + "api/posts/" + p.ID
@@ -1070,7 +1072,8 @@ func (p *PublicPost) ActivityObject() *activitystreams.Object {
 	if p.HTMLContent == template.HTML("") {
 		p.formatContent(false)
 	}
-	o.Content = string(p.HTMLContent)
+	strippedHTML := newlineRegex.ReplaceAllString(string(p.HTMLContent), "")
+	o.Content = strippedHTML
 	if p.Language.Valid {
 		o.ContentMap = map[string]string{
 			p.Language.String: string(p.HTMLContent),


### PR DESCRIPTION
Some federated services, like Mastodon, interpret newlines in Html literally. Since it costs nothing (and saves a few bytes) to strip newlines from the HTML output, of the Article object, this commit does just that.

What posts look like in Mastodon (modified to have `Article` accepted) before:

<img width="345" alt="image" src="https://user-images.githubusercontent.com/266454/56982893-32226900-6b37-11e9-8f98-d3d180dec563.png">

And after this PR:

<img width="347" alt="image" src="https://user-images.githubusercontent.com/266454/56982922-423a4880-6b37-11e9-8232-8ae8942a36bf.png">

---

- [X] I have signed the [CLA](https://phabricator.write.as/L1)
