### PR TITLE
Added /bin/lessc path to be compatible with CentOS 7

### DIFF
--- a/less/Makefile
+++ b/less/Makefile
@@ -2,6 +2,8 @@ ifeq ($(shell which lessc),/usr/bin/lessc)
 	LESSC=/usr/bin/lessc
 else ifeq ($(shell which lessc),/usr/local/bin/lessc)
 	LESSC=/usr/local/bin/lessc
+else ifeq ($(shell which lessc),/bin/lessc)
+	LESSC=/bin/lessc
 else
 	LESSC=node_modules/.bin/lessc
 endif
@@ -14,7 +16,7 @@ all :
 	$(LESSC) fonts.less --clean-css="--s1 --advanced" $(CSSDIR)fonts.css
 	$(LESSC) icons.less --clean-css="--s1 --advanced" $(CSSDIR)icons.css
 
-install : 
+install :
 	./install-less.sh
 	$(MAKE) all
 


### PR DESCRIPTION
When lessc is installed via npm in CentOS 7, path returned by `which lessc` is `/bin/lessc`. With this path being added to `less/Makefile` building WriteFreely will succeed on CentOS and will not require manual modification as I was describing in [my WriteFreely building guide](https://fedi.dev/gytis/build-writefreely-from-source).

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
