### PR TITLE
Enable un-setting RTL setting via web

### DIFF
--- a/posts.go
+++ b/posts.go
@@ -67,7 +67,8 @@ type (
 	}
 
 	AuthenticatedPost struct {
-		ID string `json:"id" schema:"id"`
+		ID  string `json:"id" schema:"id"`
+		Web bool   `json:"web" schema:"web"`
 		*SubmittedPost
 	}
 
@@ -621,6 +622,10 @@ func existingPost(app *app, w http.ResponseWriter, r *http.Request) error {
 			log.Error("Couldn't decode post update form request: %v\n", err)
 			return ErrBadFormData
 		}
+	}
+
+	if p.Web {
+		p.IsRTL.Valid = true
 	}
 
 	if p.SubmittedPost == nil {

--- a/templates/edit-meta.tmpl
+++ b/templates/edit-meta.tmpl
@@ -263,6 +263,7 @@
 					</dd>
 					<dt>&nbsp;</dt><dd><input type="submit" value="Save changes" /></dd>
 				</dl>
+				<input type="hidden" name="web" value="true" />
 			</form>
 		</div>
 		


### PR DESCRIPTION
Previously, once RTL was enabled on a post, you couldn't unset it via
the web application. This fixes that. (Fixes #103)