### PR TITLE
Modify GetPost() to allow inclusion of pinned posts

### DIFF
--- a/activitypub.go
+++ b/activitypub.go
@@ -127,7 +127,7 @@ func handleFetchCollectionOutbox(app *app, w http.ResponseWriter, r *http.Reques
 	ocp := activitystreams.NewOrderedCollectionPage(accountRoot, "outbox", res.TotalPosts, p)
 	ocp.OrderedItems = []interface{}{}
 
-	posts, err := app.db.GetPosts(c, p, false, true)
+	posts, err := app.db.GetPosts(c, p, false, true, false)
 	for _, pp := range *posts {
 		pp.Collection = res
 		o := pp.ActivityObject()

--- a/collections.go
+++ b/collections.go
@@ -492,7 +492,7 @@ func fetchCollectionPosts(app *app, w http.ResponseWriter, r *http.Request) erro
 		}
 	}
 
-	posts, err := app.db.GetPosts(c, page, isCollOwner, false)
+	posts, err := app.db.GetPosts(c, page, isCollOwner, false, false)
 	if err != nil {
 		return err
 	}
@@ -723,7 +723,7 @@ func handleViewCollection(app *app, w http.ResponseWriter, r *http.Request) erro
 		return impart.HTTPError{http.StatusFound, redirURL}
 	}
 
-	coll.Posts, _ = app.db.GetPosts(c, page, cr.isCollOwner, false)
+	coll.Posts, _ = app.db.GetPosts(c, page, cr.isCollOwner, false, false)
 
 	// Serve collection
 	displayPage := CollectionPage{

--- a/database.go
+++ b/database.go
@@ -1062,8 +1062,9 @@ func (db *datastore) GetPostsCount(c *CollectionObj, includeFuture bool) {
 	c.TotalPosts = int(count)
 }
 
-// GetPosts retrieves all standard (non-pinned) posts for the given Collection.
+// GetPosts retrieves all posts for the given Collection.
 // It will return future posts if `includeFuture` is true.
+// It will include only standard (non-pinned) posts unless `includePinned` is true.
 // TODO: change includeFuture to isOwner, since that's how it's used
 func (db *datastore) GetPosts(c *Collection, page int, includeFuture, forceRecentFirst, includePinned bool) (*[]PublicPost, error) {
 	collID := c.ID

--- a/export.go
+++ b/export.go
@@ -111,7 +111,7 @@ func compileFullExport(app *app, u *User) *ExportUser {
 	var collObjs []CollectionObj
 	for _, c := range *colls {
 		co := &CollectionObj{Collection: c}
-		co.Posts, err = app.db.GetPosts(&c, 0, true, false)
+		co.Posts, err = app.db.GetPosts(&c, 0, true, false, true)
 		if err != nil {
 			log.Error("unable to get collection posts: %v", err)
 		}

--- a/feed.go
+++ b/feed.go
@@ -56,7 +56,7 @@ func ViewFeed(app *app, w http.ResponseWriter, req *http.Request) error {
 	if tag != "" {
 		coll.Posts, _ = app.db.GetPostsTagged(c, tag, 1, false)
 	} else {
-		coll.Posts, _ = app.db.GetPosts(c, 1, false, true)
+		coll.Posts, _ = app.db.GetPosts(c, 1, false, true, false)
 	}
 
 	author := ""

--- a/sitemap.go
+++ b/sitemap.go
@@ -64,7 +64,7 @@ func handleViewSitemap(app *app, w http.ResponseWriter, r *http.Request) error {
 	host = c.CanonicalURL()
 
 	sm := buildSitemap(host, pre)
-	posts, err := app.db.GetPosts(c, 0, false, false)
+	posts, err := app.db.GetPosts(c, 0, false, false, false)
 	if err != nil {
 		log.Error("Error getting posts: %v", err)
 		return err


### PR DESCRIPTION
This PR modifies the `GetPost()` function in [database.go](https://github.com/writeas/writefreely/blob/95e84a1d0e3e23a3156ab624b2f5e9b51ef9a8ba/database.go#L1068-L1123) to add an additional parameter, `includePinned`. When `includePinned` is `false`, the SQL query to fetch posts will include the clause `AND pinned_position IS NULL`; when `includePinned` is `true`, that clause is left out.

In addition, this PR updates all calls to `GetPost()` to include an argument for the new position. Currently this is `false` everywhere but [export.go](https://github.com/writeas/writefreely/blob/95e84a1d0e3e23a3156ab624b2f5e9b51ef9a8ba/export.go#L114), where the argument is `true` to ensure that all posts (including pinned posts) are exported as JSON.

I'm going with this one rather than `fix-json-export` because it's easier to maintain in the future (since we won't have two copies of a largely-identical function to manage).

This should resolve #112.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
