### PR TITLE
Make post body h2's smaller on index pages

### DIFF
--- a/less/core.less
+++ b/less/core.less
@@ -252,6 +252,8 @@ body {
 				margin-bottom: 0.25em;
 				&+time {
 					display: block;
+					margin-top: 0.25em;
+					margin-bottom: 0.25em;
 				}
 			}
 			time {

--- a/less/core.less
+++ b/less/core.less
@@ -604,6 +604,9 @@ body#collection article, body#subpage article {
 	padding-top: 0;
 	padding-bottom: 0;
 	.book {
+		h2 {
+			font-size: 1.4em;
+		}
 		a.hidden.action {
 			 color: #666;
 			 float: right;


### PR DESCRIPTION
Previously, \<h2>s in a post were the exact same size as post titles on
index pages (blog index, tag listing). This fixes that by reducing the
font-size of body h2's. Closes #82.