### PR TITLE
Support reversing tags

### DIFF
--- a/database.go
+++ b/database.go
@@ -105,7 +105,7 @@ type writestore interface {
 
 	GetPostsCount(c *CollectionObj, includeFuture bool)
 	GetPosts(c *Collection, page int, includeFuture, forceRecentFirst, includePinned bool) (*[]PublicPost, error)
-	GetPostsTagged(c *Collection, tag string, page int, includeFuture bool) (*[]PublicPost, error)
+	GetPostsTagged(c *Collection, tag string, page int, includeFuture bool, reversed bool) (*[]PublicPost, error)
 
 	GetAPFollowers(c *Collection) (*[]RemoteUser, error)
 	GetAPActorKeys(collectionID int64) ([]byte, []byte)
@@ -1069,7 +1069,7 @@ func (db *datastore) GetPostsCount(c *CollectionObj, includeFuture bool) {
 func (db *datastore) GetPosts(c *Collection, page int, includeFuture, forceRecentFirst, includePinned bool) (*[]PublicPost, error) {
 	collID := c.ID
 
-	cf := c.NewFormat()
+	cf := c.NewFormat(false)
 	order := "DESC"
 	if cf.Ascending() && !forceRecentFirst {
 		order = "ASC"
@@ -1127,10 +1127,10 @@ func (db *datastore) GetPosts(c *Collection, page int, includeFuture, forceRecen
 // given tag.
 // It will return future posts if `includeFuture` is true.
 // TODO: change includeFuture to isOwner, since that's how it's used
-func (db *datastore) GetPostsTagged(c *Collection, tag string, page int, includeFuture bool) (*[]PublicPost, error) {
+func (db *datastore) GetPostsTagged(c *Collection, tag string, page int, includeFuture bool, reversed bool) (*[]PublicPost, error) {
 	collID := c.ID
 
-	cf := c.NewFormat()
+	cf := c.NewFormat(reversed)
 	order := "DESC"
 	if cf.Ascending() {
 		order = "ASC"

--- a/feed.go
+++ b/feed.go
@@ -54,7 +54,7 @@ func ViewFeed(app *app, w http.ResponseWriter, req *http.Request) error {
 
 	tag := mux.Vars(req)["tag"]
 	if tag != "" {
-		coll.Posts, _ = app.db.GetPostsTagged(c, tag, 1, false)
+		coll.Posts, _ = app.db.GetPostsTagged(c, tag, 1, false, false)
 	} else {
 		coll.Posts, _ = app.db.GetPosts(c, 1, false, true, false)
 	}

--- a/routes.go
+++ b/routes.go
@@ -170,6 +170,7 @@ func initRoutes(handler *Handler, r *mux.Router, cfg *config.Config, db *datasto
 func RouteCollections(handler *Handler, r *mux.Router) {
 	r.HandleFunc("/page/{page:[0-9]+}", handler.Web(handleViewCollection, UserLevelOptional))
 	r.HandleFunc("/tag:{tag}", handler.Web(handleViewCollectionTag, UserLevelOptional))
+	r.HandleFunc("/tag:{tag}/rev", handler.Web(handleViewCollectionTag, UserLevelOptional))
 	r.HandleFunc("/tag:{tag}/feed/", handler.Web(ViewFeed, UserLevelOptional))
 	r.HandleFunc("/tags/{tag}", handler.Web(handleViewCollectionTag, UserLevelOptional))
 	r.HandleFunc("/sitemap.xml", handler.All(handleViewSitemap))


### PR DESCRIPTION
You can now use `/tag:test/rev` instead of `/tag:test/` to reverse the order from the default for that collection.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
 - I didn't get a confirmation email