### PR TITLE
Always initialize database after --config

### DIFF
--- a/app.go
+++ b/app.go
@@ -449,19 +449,21 @@ func DoConfig(app *App) {
 		log.Error("Unable to configure: %v", err)
 		os.Exit(1)
 	}
-	if d.User != nil {
-		app.cfg = d.Config
-		connectToDatabase(app)
-		defer shutdown(app)
+	app.cfg = d.Config
+	connectToDatabase(app)
+	defer shutdown(app)
 
-		if !app.db.DatabaseInitialized() {
-			err = adminInitDatabase(app)
-			if err != nil {
-				log.Error(err.Error())
-				os.Exit(1)
-			}
+	if !app.db.DatabaseInitialized() {
+		err = adminInitDatabase(app)
+		if err != nil {
+			log.Error(err.Error())
+			os.Exit(1)
 		}
+	} else {
+		log.Info("Database already initialized.")
+	}
 
+	if d.User != nil {
 		u := &User{
 			Username:   d.User.Username,
 			HashedPass: d.User.HashedPass,


### PR DESCRIPTION
**Always initialize database after --config**

Previously, this would only run when configuring an instance for single-user usage. Now it'll also run when configuring for multi-user usage.

It also adds a log when the database has already been initialized.

---

_Previous PR description:_

This improves the interactive configuration process that runs with the `--config` flag present -- particularly to support our work on a DigitalOcean one-click install image ([T600](https://phabricator.write.as/T600)).

* Always initialize database after --config
* ~~TODO: Support shorter config process ([T657](https://phabricator.write.as/T657))~~ See #127 