### PR TITLE
Don't consider post unpublished when title exists

### DIFF
--- a/database.go
+++ b/database.go
@@ -926,7 +926,7 @@ func (db *datastore) GetEditablePost(id, editToken string) (*PublicPost, error) 
 		return nil, err
 	}
 
-	if p.Content == "" {
+	if p.Content == "" && p.Title.String == "" {
 		return nil, ErrPostUnpublished
 	}
 
@@ -976,7 +976,7 @@ func (db *datastore) GetPost(id string, collectionID int64) (*PublicPost, error)
 		return nil, err
 	}
 
-	if p.Content == "" {
+	if p.Content == "" && p.Title.String == "" {
 		return nil, ErrPostUnpublished
 	}
 
@@ -1005,7 +1005,7 @@ func (db *datastore) GetOwnedPost(id string, ownerID int64) (*PublicPost, error)
 		return nil, err
 	}
 
-	if p.Content == "" {
+	if p.Content == "" && p.Title.String == "" {
 		return nil, ErrPostUnpublished
 	}
 

--- a/posts.go
+++ b/posts.go
@@ -1299,7 +1299,7 @@ func viewCollectionPost(app *App, w http.ResponseWriter, r *http.Request) error 
 	p.IsTopLevel = app.cfg.App.SingleUser
 
 	// Check if post has been unpublished
-	if p.Content == "" {
+	if p.Content == "" && p.Title.String == "" {
 		return impart.HTTPError{http.StatusGone, "Post was unpublished."}
 	}
 


### PR DESCRIPTION
Previously, you could create a post with a title but no body, e.g. by publishing via email, and it would still show the post on a blog but give a 410 Gone page when trying to access the page. This fixes that.

This issue originally reported [on the forum](https://discuss.write.as/t/removing-post-unpublished-by-author-post/725)