### PR TITLE
Fix go-sitemap-generator overriding GOMAXPROCs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,11 @@ require (
 	github.com/Unknwon/i18n v0.0.0-20171114194641-b64d33658966 // indirect
 	github.com/alecthomas/gometalinter v3.0.0+incompatible // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
-	github.com/beevik/etree v1.1.0 // indirect
 	github.com/bradfitz/gomemcache v0.0.0-20180710155616-bc664df96737 // indirect
 	github.com/captncraig/cors v0.0.0-20180620154129-376d45073b49 // indirect
 	github.com/clbanning/mxj v1.8.4 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.7.0
-	github.com/fatih/structs v1.1.0 // indirect
 	github.com/go-macaron/cache v0.0.0-20151013081102-561735312776 // indirect
 	github.com/go-macaron/inject v0.0.0-20160627170012-d8a0b8677191 // indirect
 	github.com/go-macaron/session v0.0.0-20190131233854-0a0a789bf193 // indirect
@@ -31,6 +29,7 @@ require (
 	github.com/gorilla/sessions v1.1.3
 	github.com/guregu/null v3.4.0+incompatible
 	github.com/ikeikeikeike/go-sitemap-generator v1.0.1
+	github.com/ikeikeikeike/go-sitemap-generator/v2 v2.0.2
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/jtolds/gls v4.2.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5O
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/clbanning/mxj v1.8.3/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
 github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
 github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
@@ -81,6 +82,8 @@ github.com/guregu/null v3.4.0+incompatible h1:a4mw37gBO7ypcBlTJeZGuMpSxxFTV9qFfF
 github.com/guregu/null v3.4.0+incompatible/go.mod h1:ePGpQaN9cw0tj45IR5E5ehMvsFlLlQZAkkOXZurJ3NM=
 github.com/ikeikeikeike/go-sitemap-generator v1.0.1 h1:49Fn8gro/B12vCY8pf5/+/Jpr3kwB9TvP0MSymo69SY=
 github.com/ikeikeikeike/go-sitemap-generator v1.0.1/go.mod h1:QI+zWsz6yQyxkG9LWNcnu0f7aiAE5tPdsZOsICgmd1c=
+github.com/ikeikeikeike/go-sitemap-generator/v2 v2.0.2 h1:wIdDEle9HEy7vBPjC6oKz6ejs3Ut+jmsYvuOoAW2pSM=
+github.com/ikeikeikeike/go-sitemap-generator/v2 v2.0.2/go.mod h1:WtaVKD9TeruTED9ydiaOJU08qGoEPP/LyzTKiD3jEsw=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=

--- a/sitemap.go
+++ b/sitemap.go
@@ -12,11 +12,12 @@ package writefreely
 
 import (
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/gorilla/mux"
 	"github.com/ikeikeikeike/go-sitemap-generator/v2/stm"
 	"github.com/writeas/web-core/log"
-	"net/http"
-	"time"
 )
 
 func buildSitemap(host, alias string) *stm.Sitemap {
@@ -81,16 +82,16 @@ func handleViewSitemap(app *App, w http.ResponseWriter, r *http.Request) error {
 			{"mobile", true},
 			{"lastmod", p.Updated},
 		}
-		/*
-			if len(p.Images) > 0 {
-				imgs := []stm.URL{}
-				for _, i := range p.Images {
-					imgs = append(imgs, stm.URL{{"loc", i}, {"title", ""}})
-				}
-				// FIXME: this is a pain. At a loss on how to do this
-				u = append(u, []interface{}{[]interface{}{"image": imgs}})
+		if len(p.Images) > 0 {
+			imgs := stm.URL{}
+			for _, i := range p.Images {
+				imgs = append(imgs, []interface{}{
+					[]interface{}{"loc", i},
+					[]interface{}{"title", ""},
+				})
 			}
-		*/
+			u = append(u, []interface{}{"image", imgs})
+		}
 		sm.Add(u)
 	}
 

--- a/sitemap.go
+++ b/sitemap.go
@@ -13,14 +13,14 @@ package writefreely
 import (
 	"fmt"
 	"github.com/gorilla/mux"
-	"github.com/ikeikeikeike/go-sitemap-generator/stm"
+	"github.com/ikeikeikeike/go-sitemap-generator/v2/stm"
 	"github.com/writeas/web-core/log"
 	"net/http"
 	"time"
 )
 
 func buildSitemap(host, alias string) *stm.Sitemap {
-	sm := stm.NewSitemap()
+	sm := stm.NewSitemap(0)
 	sm.SetDefaultHost(host)
 	if alias != "/" {
 		sm.SetSitemapsPath(alias)
@@ -76,27 +76,30 @@ func handleViewSitemap(app *App, w http.ResponseWriter, r *http.Request) error {
 			lastSiteMod = p.Updated
 		}
 		u := stm.URL{
-			"loc":        p.Slug.String,
-			"changefreq": "weekly",
-			"mobile":     true,
-			"lastmod":    p.Updated,
+			{"loc", p.Slug.String},
+			{"changefreq", "weekly"},
+			{"mobile", true},
+			{"lastmod", p.Updated},
 		}
-		if len(p.Images) > 0 {
-			imgs := []stm.URL{}
-			for _, i := range p.Images {
-				imgs = append(imgs, stm.URL{"loc": i, "title": ""})
+		/*
+			if len(p.Images) > 0 {
+				imgs := []stm.URL{}
+				for _, i := range p.Images {
+					imgs = append(imgs, stm.URL{{"loc", i}, {"title", ""}})
+				}
+				// FIXME: this is a pain. At a loss on how to do this
+				u = append(u, []interface{}{[]interface{}{"image": imgs}})
 			}
-			u["image"] = imgs
-		}
+		*/
 		sm.Add(u)
 	}
 
 	// Add top URL
 	sm.Add(stm.URL{
-		"loc":        pre,
-		"changefreq": "daily",
-		"priority":   "1.0",
-		"lastmod":    lastSiteMod,
+		{"loc", pre},
+		{"changefreq", "daily"},
+		{"priority", "1.0"},
+		{"lastmod", lastSiteMod},
 	})
 
 	w.Write(sm.XMLContent())

--- a/sitemap.go
+++ b/sitemap.go
@@ -83,11 +83,11 @@ func handleViewSitemap(app *App, w http.ResponseWriter, r *http.Request) error {
 			{"lastmod", p.Updated},
 		}
 		if len(p.Images) > 0 {
-			imgs := stm.URL{}
+			imgs := []stm.URL{}
 			for _, i := range p.Images {
-				imgs = append(imgs, []interface{}{
-					[]interface{}{"loc", i},
-					[]interface{}{"title", ""},
+				imgs = append(imgs, stm.URL{
+					{"loc", i},
+					{"title", ""},
 				})
 			}
 			u = append(u, []interface{}{"image", imgs})


### PR DESCRIPTION
This upgrades the `go-sitemap-generator` library to v2, which lets you specify that GOMAXPROCs should always be the max number of CPUs -- and then sets it to that.

One side effect of this is that images are no longer listed in sitemaps. I'm somehow at a loss on how to build and append the images array we need, with the library's latest changes. Ideally we'd fix this -- any help would be much appreciated.

Fixes #86