### PR TITLE
Automatic certificates from Let's Encrypt

### DIFF
--- a/app.go
+++ b/app.go
@@ -393,11 +393,21 @@ func Serve(app *App, r *mux.Router) {
 
 		log.Info("Serving on https://%s:443", bindAddress)
 		if app.cfg.Server.Autocert {
-			log.Info("Using autocert")
 			m := &autocert.Manager{
-				Prompt:     autocert.AcceptTOS,
-				Cache:      autocert.DirCache(app.cfg.Server.TLSCertPath),
-				HostPolicy: autocert.HostWhitelist(app.cfg.App.Host),
+				Prompt: autocert.AcceptTOS,
+				Cache:  autocert.DirCache(app.cfg.Server.TLSCertPath),
+			}
+			host, err := url.Parse(app.cfg.App.Host)
+			if err != nil {
+				log.Error("[WARNING] Unable to parse configured host! %s", err)
+				log.Error(`[WARNING] ALL hosts are allowed, which can open you to an attack where
+clients connect to a server by IP address and pretend to be asking for an
+incorrect host name, and cause you to reach the CA's rate limit for certificate
+requests. We recommend supplying a valid host name.`)
+				log.Info("Using autocert on ANY host")
+			} else {
+				log.Info("Using autocert on host %s", host.Host)
+				m.HostPolicy = autocert.HostWhitelist(host.Host)
 			}
 			s := &http.Server{
 				Addr:    ":https",

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type (
 
 		TLSCertPath string `ini:"tls_cert_path"`
 		TLSKeyPath  string `ini:"tls_key_path"`
+		Autocert    bool   `ini:"autocert"`
 
 		TemplatesParentDir string `ini:"templates_parent_dir"`
 		StaticParentDir    string `ini:"static_parent_dir"`


### PR DESCRIPTION
This enables admins to run WriteFreely as a standalone server that automatically generates certificates, powered by Let's Encrypt ([T542](https://writefreely.org/tasks/542)).

It adds a new config option under the `[server]` section: `autocert`. When set to `true` (and with non-empty `tls_cert_path` and `tls_key_path` values, plus `port = 443`), WriteFreely will serve the instance on port 443 and automatically generate a certificate for the configured host.

This also adds a new option during the interactive config process that allows the user to choose automatic certificate generation, in addition to the previous option of manually configuring the certificate location.