### PR TITLE
Fix missing hostname when publishing via API

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -211,6 +211,10 @@ func (c *Collection) DisplayCanonicalURL() string {
 }
 
 func (c *Collection) RedirectingCanonicalURL(isRedir bool) string {
+	if c.hostName == "" {
+		// If this is true, the human programmers screwed up. So ask for a bug report and fail, fail, fail
+		log.Error("[PROGRAMMER ERROR] WARNING: Collection.hostName is empty! Federation and many other things will fail! If you're seeing this in the wild, please report this bug and let us know what you were doing just before this: https://github.com/writeas/writefreely/issues/new?template=bug_report.md")
+	}
 	if isSingleUser {
 		return c.hostName + "/"
 	}

--- a/database.go
+++ b/database.go
@@ -73,7 +73,7 @@ type writestore interface {
 	GetAnonymousPosts(u *User) (*[]PublicPost, error)
 	GetUserPosts(u *User) (*[]PublicPost, error)
 
-	CreateOwnedPost(post *SubmittedPost, accessToken, collAlias string) (*PublicPost, error)
+	CreateOwnedPost(post *SubmittedPost, accessToken, collAlias, hostName string) (*PublicPost, error)
 	CreatePost(userID, collID int64, post *SubmittedPost) (*Post, error)
 	UpdateOwnedPost(post *AuthenticatedPost, userID int64) error
 	GetEditablePost(id, editToken string) (*PublicPost, error)
@@ -541,7 +541,7 @@ func (db *datastore) GetTemporaryOneTimeAccessToken(userID int64, validSecs int,
 	return u.String(), nil
 }
 
-func (db *datastore) CreateOwnedPost(post *SubmittedPost, accessToken, collAlias string) (*PublicPost, error) {
+func (db *datastore) CreateOwnedPost(post *SubmittedPost, accessToken, collAlias, hostName string) (*PublicPost, error) {
 	var userID, collID int64 = -1, -1
 	var coll *Collection
 	var err error
@@ -555,6 +555,7 @@ func (db *datastore) CreateOwnedPost(post *SubmittedPost, accessToken, collAlias
 			if err != nil {
 				return nil, err
 			}
+			coll.hostName = hostName
 			if coll.OwnerID != userID {
 				return nil, ErrForbiddenCollection
 			}

--- a/posts.go
+++ b/posts.go
@@ -556,7 +556,7 @@ func newPost(app *App, w http.ResponseWriter, r *http.Request) error {
 	var coll *Collection
 	var err error
 	if accessToken != "" {
-		newPost, err = app.db.CreateOwnedPost(p, accessToken, collAlias)
+		newPost, err = app.db.CreateOwnedPost(p, accessToken, collAlias, app.cfg.App.Host)
 	} else {
 		//return ErrNotLoggedIn
 		// TODO: verify user is logged in


### PR DESCRIPTION
This fixes a bug that occurred only when publishing via API and authenticating via token (rather than cookie). I noticed this while testing the new `wf-cli`.

Previously, the instance's hostname wouldn't be added to the `Collection` that got passed around after retrieving the owned post, meaning an incomplete URL was returned in the API response, and federation failed due to the missing host (and thus failed key lookup).