### PR TITLE
Fix single-user instance issues

### DIFF
--- a/templates/collection-tags.tmpl
+++ b/templates/collection-tags.tmpl
@@ -141,7 +141,7 @@ function pinPost(e, postID, slug, title) {
 		var $header = document.getElementsByTagName('header')[0];
 		var $pinnedNavs = $header.getElementsByTagName('nav');
 		// Add link to nav
-		var link = '<a class="pinned" href="/{{.Alias}}/'+slug+'">'+title+'</a>';
+		var link = '<a class="pinned" href="{{if not .SingleUser}}/{{.Alias}}/{{end}}'+slug+'">'+title+'</a>';
 		if ($pinnedNavs.length == 0) {
 			$header.insertAdjacentHTML("beforeend", '<nav>'+link+'</nav>');
 		} else {

--- a/templates/collection.tmpl
+++ b/templates/collection.tmpl
@@ -176,7 +176,7 @@ function pinPost(e, postID, slug, title) {
 		var $header = document.getElementsByTagName('header')[0];
 		var $pinnedNavs = $header.getElementsByTagName('nav');
 		// Add link to nav
-		var link = '<a class="pinned" href="/{{.Alias}}/'+slug+'">'+title+'</a>';
+		var link = '<a class="pinned" href="{{if not .SingleUser}}/{{.Alias}}/{{end}}'+slug+'">'+title+'</a>';
 		if ($pinnedNavs.length == 0) {
 			$header.insertAdjacentHTML("beforeend", '<nav>'+link+'</nav>');
 		} else {

--- a/templates/user/articles.tmpl
+++ b/templates/user/articles.tmpl
@@ -34,8 +34,8 @@
 		{{if .Summary}}<p>{{.Summary}}</p>{{end}}
 	</div>{{end}}
 </div>{{ else }}<div id="no-posts-published"><p>You haven't saved any drafts yet.</p>
-	<p>They'll show up here once you do. Find your blog posts from the <a href="/me/c/">Blogs</a> page.</p>
-	<p class="text-cta"><a href="/">Start writing</a></p></div>{{ end }}
+	<p>They'll show up here once you do. {{if not .SingleUser}}Find your blog posts from the <a href="/me/c/">Blogs</a> page.{{end}}</p>
+	<p class="text-cta"><a href="{{if .SingleUser}}/me/new{{else}}/{{end}}">Start writing</a></p></div>{{ end }}
 
 <div id="moving"></div>
 

--- a/templates/user/collection.tmpl
+++ b/templates/user/collection.tmpl
@@ -58,6 +58,7 @@
 					</label>
 					<p>A password is required to read this blog.</p>
 				</li>
+				{{if not .SingleUser}}
 				<li>
 					<label class="option-text{{if not .LocalTimeline}} disabled{{end}}"><input type="radio" name="visibility" id="visibility-public" value="1" {{if .IsPublic}}checked="checked"{{end}} {{if not .LocalTimeline}}disabled="disabled"{{end}} />
 						Public
@@ -65,6 +66,7 @@
 					{{if .LocalTimeline}}<p>This blog is displayed on the public <a href="/read">reader</a>, and is visible to {{if .Private}}any registered user on this instance{{else}}anyone with its link{{end}}.</p>
 					{{else}}<p>The public reader is currently turned off for this community.</p>{{end}}
 				</li>
+				{{end}}
 			</ul>
 		</div>
 	</div>

--- a/templates/user/include/footer.tmpl
+++ b/templates/user/include/footer.tmpl
@@ -8,10 +8,10 @@
 		<hr />
 		<nav>
 			<a class="home" href="/">{{.SiteName}}</a>
-			<a href="/about">about</a>
+			{{if not .SingleUser}}<a href="/about">about</a>{{end}}
 			{{if and (not .SingleUser) .LocalTimeline}}<a href="/read">reader</a>{{end}}
 			<a href="https://writefreely.org/guide/{{.OfficialVersion}}" target="guide">writer's guide</a>
-			<a href="/privacy">privacy</a>
+			{{if not .SingleUser}}<a href="/privacy">privacy</a>{{end}}
 			<a href="https://writefreely.org">writefreely {{.Version}}</a>
 		</nav>
 	</footer>


### PR DESCRIPTION
While running a single-user instance on https://matt.writefreely.dev I've noticed some (mostly superficial) issues, and [documented them here](https://matt.writefreely.dev/single-user-issues-so-far):

- [x] “Public” option shows on blog Customize page (should never be there in this mode)
- [x] Pinning a post links to /matt/about instead of /about
- [x] Instance-level About page shows at the bottom of user pages (should never show in this mode)
- [x] Drafts page shows “Find your blog posts from the Blogs page.” (should never show in this mode)

This PR aims to fix those issues.