### PR TITLE
Support setting default blog visibility on instance

### DIFF
--- a/account.go
+++ b/account.go
@@ -163,7 +163,7 @@ func signupWithRegistration(app *App, signup userRegistration, w http.ResponseWr
 	}
 
 	// Create actual user
-	if err := app.db.CreateUser(app, u, desiredUsername); err != nil {
+	if err := app.db.CreateUser(app.cfg, u, desiredUsername); err != nil {
 		return nil, err
 	}
 

--- a/account.go
+++ b/account.go
@@ -163,7 +163,7 @@ func signupWithRegistration(app *App, signup userRegistration, w http.ResponseWr
 	}
 
 	// Create actual user
-	if err := app.db.CreateUser(u, desiredUsername); err != nil {
+	if err := app.db.CreateUser(app, u, desiredUsername); err != nil {
 		return nil, err
 	}
 

--- a/admin.go
+++ b/admin.go
@@ -391,6 +391,7 @@ func handleAdminUpdateConfig(apper Apper, u *User, w http.ResponseWriter, r *htt
 	if apper.App().cfg.App.UserInvites == "none" {
 		apper.App().cfg.App.UserInvites = ""
 	}
+	apper.App().cfg.App.DefaultVisibility = r.FormValue("default_visibility")
 
 	m := "?cm=Configuration+saved."
 	err = apper.SaveConfig(apper.App().cfg)

--- a/app.go
+++ b/app.go
@@ -507,7 +507,7 @@ func DoConfig(app *App, configSections string) {
 
 		// Create blog
 		log.Info("Creating user %s...\n", u.Username)
-		err = app.db.CreateUser(app, u, app.cfg.App.SiteName)
+		err = app.db.CreateUser(app.cfg, u, app.cfg.App.SiteName)
 		if err != nil {
 			log.Error("Unable to create user: %s", err)
 			os.Exit(1)
@@ -702,7 +702,7 @@ func CreateUser(apper Apper, username, password string, isAdmin bool) error {
 		userType = "admin"
 	}
 	log.Info("Creating %s %s...", userType, usernameDesc)
-	err = apper.App().db.CreateUser(apper.App(), u, desiredUsername)
+	err = apper.App().db.CreateUser(apper.App().Config(), u, desiredUsername)
 	if err != nil {
 		return fmt.Errorf("Unable to create user: %s", err)
 	}

--- a/app.go
+++ b/app.go
@@ -507,7 +507,7 @@ func DoConfig(app *App, configSections string) {
 
 		// Create blog
 		log.Info("Creating user %s...\n", u.Username)
-		err = app.db.CreateUser(u, app.cfg.App.SiteName)
+		err = app.db.CreateUser(app, u, app.cfg.App.SiteName)
 		if err != nil {
 			log.Error("Unable to create user: %s", err)
 			os.Exit(1)
@@ -702,7 +702,7 @@ func CreateUser(apper Apper, username, password string, isAdmin bool) error {
 		userType = "admin"
 	}
 	log.Info("Creating %s %s...", userType, usernameDesc)
-	err = apper.App().db.CreateUser(u, desiredUsername)
+	err = apper.App().db.CreateUser(apper.App(), u, desiredUsername)
 	if err != nil {
 		return fmt.Errorf("Unable to create user: %s", err)
 	}

--- a/collections.go
+++ b/collections.go
@@ -396,23 +396,10 @@ func newCollection(app *App, w http.ResponseWriter, r *http.Request) error {
 		return impart.HTTPError{http.StatusPreconditionFailed, "Collection alias isn't valid."}
 	}
 
-	coll, err := app.db.CreateCollection(c.Alias, c.Title, userID)
+	coll, err := app.db.CreateCollection(app.cfg, c.Alias, c.Title, userID)
 	if err != nil {
 		// TODO: handle this
 		return err
-	}
-
-	// Set visibility to configured default
-	vis := defaultVisibility(app.cfg)
-	if vis != CollUnlisted {
-		visInt := int(vis)
-		err = app.db.UpdateCollection(&SubmittedCollection{
-			OwnerID:    uint64(userID),
-			Visibility: &visInt,
-		}, coll.Alias)
-		if err != nil {
-			log.Error("Unable to set default visibility: %s", err)
-		}
 	}
 
 	res := &CollectionObj{Collection: *coll}

--- a/collections.go
+++ b/collections.go
@@ -31,6 +31,7 @@ import (
 	"github.com/writeas/web-core/log"
 	waposts "github.com/writeas/web-core/posts"
 	"github.com/writeas/writefreely/author"
+	"github.com/writeas/writefreely/config"
 	"github.com/writeas/writefreely/page"
 )
 
@@ -125,6 +126,21 @@ const (
 	CollPrivate
 	CollProtected
 )
+
+var collVisibilityStrings = map[string]collVisibility{
+	"unlisted":  CollUnlisted,
+	"public":    CollPublic,
+	"private":   CollPrivate,
+	"protected": CollProtected,
+}
+
+func defaultVisibility(cfg *config.Config) collVisibility {
+	vis, ok := collVisibilityStrings[cfg.App.DefaultVisibility]
+	if !ok {
+		vis = CollUnlisted
+	}
+	return vis
+}
 
 func (cf *CollectionFormat) Ascending() bool {
 	return cf.Format == "novel"
@@ -358,35 +374,44 @@ func newCollection(app *App, w http.ResponseWriter, r *http.Request) error {
 		return impart.HTTPError{http.StatusBadRequest, fmt.Sprintf("Parameter(s) %srequired.", missingParams)}
 	}
 
+	var userID int64
 	if reqJSON && !c.Web {
 		accessToken = r.Header.Get("Authorization")
 		if accessToken == "" {
 			return ErrNoAccessToken
+		}
+		userID = app.db.GetUserID(accessToken)
+		if userID == -1 {
+			return ErrBadAccessToken
 		}
 	} else {
 		u = getUserSession(app, r)
 		if u == nil {
 			return ErrNotLoggedIn
 		}
+		userID = u.ID
 	}
 
 	if !author.IsValidUsername(app.cfg, c.Alias) {
 		return impart.HTTPError{http.StatusPreconditionFailed, "Collection alias isn't valid."}
 	}
 
-	var coll *Collection
-	var err error
-	if accessToken != "" {
-		coll, err = app.db.CreateCollectionFromToken(c.Alias, c.Title, accessToken)
+	coll, err := app.db.CreateCollection(c.Alias, c.Title, userID)
+	if err != nil {
+		// TODO: handle this
+		return err
+	}
+
+	// Set visibility to configured default
+	vis := defaultVisibility(app.cfg)
+	if vis != CollUnlisted {
+		visInt := int(vis)
+		err = app.db.UpdateCollection(&SubmittedCollection{
+			OwnerID:    uint64(userID),
+			Visibility: &visInt,
+		}, coll.Alias)
 		if err != nil {
-			// TODO: handle this
-			return err
-		}
-	} else {
-		coll, err = app.db.CreateCollection(c.Alias, c.Title, u.ID)
-		if err != nil {
-			// TODO: handle this
-			return err
+			log.Error("Unable to set default visibility: %s", err)
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -83,6 +83,9 @@ type (
 		// Additional functions
 		LocalTimeline bool   `ini:"local_timeline"`
 		UserInvites   string `ini:"user_invites"`
+
+		// Defaults
+		DefaultVisibility string `ini:"default_visibility"`
 	}
 
 	// Config holds the complete configuration for running a writefreely instance

--- a/database.go
+++ b/database.go
@@ -29,6 +29,7 @@ import (
 	"github.com/writeas/web-core/log"
 	"github.com/writeas/web-core/query"
 	"github.com/writeas/writefreely/author"
+	"github.com/writeas/writefreely/config"
 	"github.com/writeas/writefreely/key"
 )
 
@@ -44,7 +45,7 @@ var (
 )
 
 type writestore interface {
-	CreateUser(*App, *User, string) error
+	CreateUser(*config.Config, *User, string) error
 	UpdateUserEmail(keys *key.Keychain, userID int64, email string) error
 	UpdateEncryptedUserEmail(int64, []byte) error
 	GetUserByID(int64) (*User, error)
@@ -162,7 +163,7 @@ func (db *datastore) dateSub(l int, unit string) string {
 	return fmt.Sprintf("DATE_SUB(NOW(), INTERVAL %d %s)", l, unit)
 }
 
-func (db *datastore) CreateUser(app *App, u *User, collectionTitle string) error {
+func (db *datastore) CreateUser(cfg *config.Config, u *User, collectionTitle string) error {
 	if db.PostIDExists(u.Username) {
 		return impart.HTTPError{http.StatusConflict, "Invalid collection name."}
 	}
@@ -196,7 +197,7 @@ func (db *datastore) CreateUser(app *App, u *User, collectionTitle string) error
 	if collectionTitle == "" {
 		collectionTitle = u.Username
 	}
-	res, err = t.Exec("INSERT INTO collections (alias, title, description, privacy, owner_id, view_count) VALUES (?, ?, ?, ?, ?, ?)", u.Username, collectionTitle, "", defaultVisibility(app.cfg), u.ID, 0)
+	res, err = t.Exec("INSERT INTO collections (alias, title, description, privacy, owner_id, view_count) VALUES (?, ?, ?, ?, ?, ?)", u.Username, collectionTitle, "", defaultVisibility(cfg), u.ID, 0)
 	if err != nil {
 		t.Rollback()
 		if db.isDuplicateKeyErr(err) {

--- a/database.go
+++ b/database.go
@@ -44,7 +44,7 @@ var (
 )
 
 type writestore interface {
-	CreateUser(*User, string) error
+	CreateUser(*App, *User, string) error
 	UpdateUserEmail(keys *key.Keychain, userID int64, email string) error
 	UpdateEncryptedUserEmail(int64, []byte) error
 	GetUserByID(int64) (*User, error)
@@ -162,7 +162,7 @@ func (db *datastore) dateSub(l int, unit string) string {
 	return fmt.Sprintf("DATE_SUB(NOW(), INTERVAL %d %s)", l, unit)
 }
 
-func (db *datastore) CreateUser(u *User, collectionTitle string) error {
+func (db *datastore) CreateUser(app *App, u *User, collectionTitle string) error {
 	if db.PostIDExists(u.Username) {
 		return impart.HTTPError{http.StatusConflict, "Invalid collection name."}
 	}
@@ -196,7 +196,7 @@ func (db *datastore) CreateUser(u *User, collectionTitle string) error {
 	if collectionTitle == "" {
 		collectionTitle = u.Username
 	}
-	res, err = t.Exec("INSERT INTO collections (alias, title, description, privacy, owner_id, view_count) VALUES (?, ?, ?, ?, ?, ?)", u.Username, collectionTitle, "", CollUnlisted, u.ID, 0)
+	res, err = t.Exec("INSERT INTO collections (alias, title, description, privacy, owner_id, view_count) VALUES (?, ?, ?, ?, ?, ?)", u.Username, collectionTitle, "", defaultVisibility(app.cfg), u.ID, 0)
 	if err != nil {
 		t.Rollback()
 		if db.isDuplicateKeyErr(err) {

--- a/database.go
+++ b/database.go
@@ -282,6 +282,7 @@ func (db *datastore) CreateCollection(cfg *config.Config, alias, title string, u
 		Title:       title,
 		OwnerID:     userID,
 		PublicOwner: false,
+		Public:      defaultVisibility(cfg) == CollPublic,
 	}
 
 	c.ID, err = res.LastInsertId()

--- a/database.go
+++ b/database.go
@@ -83,8 +83,8 @@ type writestore interface {
 	GetOwnedPost(id string, ownerID int64) (*PublicPost, error)
 	GetPostProperty(id string, collectionID int64, property string) (interface{}, error)
 
-	CreateCollectionFromToken(string, string, string) (*Collection, error)
-	CreateCollection(string, string, int64) (*Collection, error)
+	CreateCollectionFromToken(*config.Config, string, string, string) (*Collection, error)
+	CreateCollection(*config.Config, string, string, int64) (*Collection, error)
 	GetCollectionBy(condition string, value interface{}) (*Collection, error)
 	GetCollection(alias string) (*Collection, error)
 	GetCollectionForPad(alias string) (*Collection, error)
@@ -103,7 +103,7 @@ type writestore interface {
 	CanCollect(cpr *ClaimPostRequest, userID int64) bool
 	AttemptClaim(p *ClaimPostRequest, query string, params []interface{}, slugIdx int) (sql.Result, error)
 	DispersePosts(userID int64, postIDs []string) (*[]ClaimPostResult, error)
-	ClaimPosts(userID int64, collAlias string, posts *[]ClaimPostRequest) (*[]ClaimPostResult, error)
+	ClaimPosts(cfg *config.Config, userID int64, collAlias string, posts *[]ClaimPostRequest) (*[]ClaimPostResult, error)
 
 	GetPostsCount(c *CollectionObj, includeFuture bool)
 	GetPosts(c *Collection, page int, includeFuture, forceRecentFirst, includePinned bool) (*[]PublicPost, error)
@@ -239,13 +239,13 @@ func (db *datastore) UpdateEncryptedUserEmail(userID int64, encEmail []byte) err
 	return nil
 }
 
-func (db *datastore) CreateCollectionFromToken(alias, title, accessToken string) (*Collection, error) {
+func (db *datastore) CreateCollectionFromToken(cfg *config.Config, alias, title, accessToken string) (*Collection, error) {
 	userID := db.GetUserID(accessToken)
 	if userID == -1 {
 		return nil, ErrBadAccessToken
 	}
 
-	return db.CreateCollection(alias, title, userID)
+	return db.CreateCollection(cfg, alias, title, userID)
 }
 
 func (db *datastore) GetUserCollectionCount(userID int64) (uint64, error) {
@@ -262,13 +262,13 @@ func (db *datastore) GetUserCollectionCount(userID int64) (uint64, error) {
 	return collCount, nil
 }
 
-func (db *datastore) CreateCollection(alias, title string, userID int64) (*Collection, error) {
+func (db *datastore) CreateCollection(cfg *config.Config, alias, title string, userID int64) (*Collection, error) {
 	if db.PostIDExists(alias) {
 		return nil, impart.HTTPError{http.StatusConflict, "Invalid collection name."}
 	}
 
 	// All good, so create new collection
-	res, err := db.Exec("INSERT INTO collections (alias, title, description, privacy, owner_id, view_count) VALUES (?, ?, ?, ?, ?, ?)", alias, title, "", CollUnlisted, userID, 0)
+	res, err := db.Exec("INSERT INTO collections (alias, title, description, privacy, owner_id, view_count) VALUES (?, ?, ?, ?, ?, ?)", alias, title, "", defaultVisibility(cfg), userID, 0)
 	if err != nil {
 		if db.isDuplicateKeyErr(err) {
 			return nil, impart.HTTPError{http.StatusConflict, "Collection already exists."}
@@ -1325,7 +1325,7 @@ func (db *datastore) DispersePosts(userID int64, postIDs []string) (*[]ClaimPost
 	return &res, nil
 }
 
-func (db *datastore) ClaimPosts(userID int64, collAlias string, posts *[]ClaimPostRequest) (*[]ClaimPostResult, error) {
+func (db *datastore) ClaimPosts(cfg *config.Config, userID int64, collAlias string, posts *[]ClaimPostRequest) (*[]ClaimPostResult, error) {
 	postClaimReqs := map[string]bool{}
 	res := []ClaimPostResult{}
 	postCollAlias := collAlias
@@ -1382,7 +1382,7 @@ func (db *datastore) ClaimPosts(userID int64, collAlias string, posts *[]ClaimPo
 				// This is a new collection
 				// TODO: consider removing this. This seriously complicates this
 				// method and adds another (unnecessary?) logic path.
-				coll, err = db.CreateCollection(postCollAlias, "", userID)
+				coll, err = db.CreateCollection(cfg, postCollAlias, "", userID)
 				if err != nil {
 					if err, ok := err.(impart.HTTPError); ok {
 						r.Code = err.Status

--- a/posts.go
+++ b/posts.go
@@ -869,7 +869,7 @@ func addPost(app *App, w http.ResponseWriter, r *http.Request) error {
 	collAlias := vars["alias"]
 
 	// Update all given posts
-	res, err := app.db.ClaimPosts(ownerID, collAlias, claims)
+	res, err := app.db.ClaimPosts(app.cfg, ownerID, collAlias, claims)
 	if err != nil {
 		return err
 	}

--- a/templates/user/admin.tmpl
+++ b/templates/user/admin.tmpl
@@ -95,6 +95,14 @@ p.docs {
 					<option value="admin" {{if eq .Config.UserInvites "admin"}}selected="selected"{{end}}>Admins</option>
 				</select>
 			</dd>
+			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="default_visibility">Default blog visibility</label></dt>
+			<dd{{if .Config.SingleUser}} class="invisible"{{end}}>
+				<select name="default_visibility" id="default_visibility">
+					<option value="unlisted" {{if eq .Config.DefaultVisibility "unlisted"}}selected="selected"{{end}}>Unlisted</option>
+					<option value="public" {{if eq .Config.DefaultVisibility "public"}}selected="selected"{{end}}>Public</option>
+					<option value="private" {{if eq .Config.DefaultVisibility "private"}}selected="selected"{{end}}>Private</option>
+				</select>
+			</dd>
 		</dl>
 		<input type="submit" value="Save Configuration" />
 	</div>


### PR DESCRIPTION
This adds a new `default_visibility` config value that lets an instance admin set the visibility of newly created collections: Unlisted (current default), Public, or Private.

This can also be set via the Admin UI.

Resolves [T675](https://writefreely.org/tasks/675).