### PR TITLE
Support toning down WriteFreely promotion

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,7 @@ type (
 		JSDisabled bool   `ini:"disable_js"`
 		WebFonts   bool   `ini:"webfonts"`
 		Landing    string `ini:"landing"`
+		WFModesty  bool   `ini:"wf_modesty"`
 
 		// Users
 		SingleUser       bool `ini:"single_user"`

--- a/pages.go
+++ b/pages.go
@@ -65,9 +65,9 @@ func defaultPrivacyTitle() sql.NullString {
 
 func defaultAboutPage(cfg *config.Config) string {
 	if cfg.App.Federation {
-		return `_` + cfg.App.SiteName + `_ is an interconnected place for you to write and publish, powered by WriteFreely and ActivityPub.`
+		return `_` + cfg.App.SiteName + `_ is an interconnected place for you to write and publish, powered by [WriteFreely](https://writefreely.org) and ActivityPub.`
 	}
-	return `_` + cfg.App.SiteName + `_ is a place for you to write and publish, powered by WriteFreely.`
+	return `_` + cfg.App.SiteName + `_ is a place for you to write and publish, powered by [WriteFreely](https://writefreely.org).`
 }
 
 func defaultPrivacyPolicy(cfg *config.Config) string {

--- a/pages/about.tmpl
+++ b/pages/about.tmpl
@@ -12,6 +12,7 @@
 			<p><em>{{.SiteName}}</em> is home to <strong>{{largeNumFmt .AboutStats.NumPosts}}</strong> {{pluralize "article" "articles" .AboutStats.NumPosts}} across <strong>{{largeNumFmt .AboutStats.NumBlogs}}</strong> {{pluralize "blog" "blogs" .AboutStats.NumBlogs}}.</p>
 		{{end}}
 
+		{{if not .WFModesty}}
 		<h2 style="margin-top:2em">About WriteFreely</h2>
 		<p><a href="https://writefreely.org">WriteFreely</a> is a self-hosted, decentralized blogging platform for publishing beautiful, simple blogs.</p>
 		<p>It lets you publish a single blog, or host a community of writers who can create multiple blogs under one account. You can also enable federation, which allows people in the fediverse to follow your blog, bookmark your posts, and share them with others.</p>
@@ -23,5 +24,6 @@
 				<p><a href="https://writefreely.org">WriteFreely</a></p>
 			</div>
 		</div>
+		{{end}}
 	</div>
 {{end}}

--- a/templates/include/footer.tmpl
+++ b/templates/include/footer.tmpl
@@ -1,13 +1,21 @@
 {{define "footer"}}
-		<footer{{if not .SingleUser}} class="contain-me"{{end}}>
+		<footer{{if not (or .SingleUser .WFModesty)}} class="contain-me"{{end}}>
 			<hr />
-			{{if .SingleUser}}
+			{{if or .SingleUser .WFModesty}}
 			<nav>
 				<a class="home" href="/">{{.SiteName}}</a>
-				<a href="https://writefreely.org/guide/{{.OfficialVersion}}" target="guide">writer's guide</a>
-				<a href="https://developers.write.as/" title="Build on WriteFreely with our open developer API.">developers</a>
-				<a href="https://github.com/writeas/writefreely">source code</a>
-				<a href="https://writefreely.org">writefreely {{.Version}}</a>
+				{{if not .SingleUser}}
+					<a href="/about">about</a>
+					{{if .LocalTimeline}}<a href="/read">reader</a>{{end}}
+					{{if .Username}}<a href="https://writefreely.org/guide/{{.OfficialVersion}}" target="guide">writer's guide</a>{{end}}
+					<a href="/privacy">privacy</a>
+					<p style="font-size: 0.9em">powered by <a href="https://writefreely.org">writefreely</a></p>
+				{{else}}
+					<a href="https://writefreely.org/guide/{{.OfficialVersion}}" target="guide">writer's guide</a>
+					<a href="https://developers.write.as/" title="Build on WriteFreely with our open developer API.">developers</a>
+					<a href="https://github.com/writeas/writefreely">source code</a>
+					<a href="https://writefreely.org">writefreely {{.Version}}</a>
+				{{end}}
 			</nav>
 			{{else}}
 			<div class="marketing-section">

--- a/templates/user/include/footer.tmpl
+++ b/templates/user/include/footer.tmpl
@@ -12,7 +12,11 @@
 			{{if and (not .SingleUser) .LocalTimeline}}<a href="/read">reader</a>{{end}}
 			<a href="https://writefreely.org/guide/{{.OfficialVersion}}" target="guide">writer's guide</a>
 			<a href="/privacy">privacy</a>
+			{{if .WFModesty}}
+			<p style="font-size: 0.9em">powered by <a href="https://writefreely.org">writefreely</a></p>
+			{{else}}
 			<a href="https://writefreely.org">writefreely {{.Version}}</a>
+			{{end}}
 		</nav>
 	</footer>
 


### PR DESCRIPTION
This adds a new `wf_modesty` boolean config option in the `[app]` section that removes the copious mentions of WriteFreely in uneditable places like the About page and site footers.

WriteFreely remains boastful and bumptious by default; but enabling the modesty option will tone it down and likely lead to less confusion among average users.

Resolves [T676](https://writefreely.org/tasks/676)