### PR TITLE
Add editor config option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,7 @@ type (
 
 		// Site appearance
 		Theme      string `ini:"theme"`
+		Editor     string `ini:"editor"`
 		JSDisabled bool   `ini:"disable_js"`
 		WebFonts   bool   `ini:"webfonts"`
 		Landing    string `ini:"landing"`

--- a/pad.go
+++ b/pad.go
@@ -60,6 +60,10 @@ func handleViewPad(app *App, w http.ResponseWriter, r *http.Request) error {
 
 	if action == "" && slug == "" {
 		// Not editing any post; simply render the Pad
+		if templates[padTmpl] == nil {
+			log.Info("No template '%s' found. Falling back to default 'pad' template.", padTmpl)
+			padTmpl = "pad"
+		}
 		if err = templates[padTmpl].ExecuteTemplate(w, "pad", appData); err != nil {
 			log.Error("Unable to execute template: %v", err)
 		}

--- a/pad.go
+++ b/pad.go
@@ -53,7 +53,10 @@ func handleViewPad(app *App, w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	padTmpl := "pad"
+	padTmpl := app.cfg.App.Editor
+	if padTmpl == "" {
+		padTmpl = "pad"
+	}
 
 	if action == "" && slug == "" {
 		// Not editing any post; simply render the Pad


### PR DESCRIPTION
This adds a new `editor` value in the `[app]` config section, which lets admins choose the editor template file to load for all users.

Resolves [T677](https://writefreely.org/tasks/677). See #155 for first alternative editor.