### PR TITLE
Bare editor option

### DIFF
--- a/app.go
+++ b/app.go
@@ -193,7 +193,12 @@ func handleViewHome(app *App, w http.ResponseWriter, r *http.Request) error {
 		// Show correct page based on user auth status and configured landing path
 		u := getUserSession(app, r)
 		if u != nil {
-			// User is logged in, so show the Pad
+			// User is logged in, so show the Pad or Blogs page, depending on config
+			if app.cfg.App.SimpleNav {
+				// Simple nav, so home page is Blogs page
+				return viewCollections(app, u, w, r)
+			}
+			// Default config, so home page is editor
 			return handleViewPad(app, w, r)
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,7 @@ type (
 
 		// Site appearance
 		Theme      string `ini:"theme"`
+		Editor     string `ini:"editor"`
 		JSDisabled bool   `ini:"disable_js"`
 		WebFonts   bool   `ini:"webfonts"`
 		Landing    string `ini:"landing"`

--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,7 @@ type (
 		JSDisabled bool   `ini:"disable_js"`
 		WebFonts   bool   `ini:"webfonts"`
 		Landing    string `ini:"landing"`
+		SimpleNav  bool   `ini:"simple_nav"`
 
 		// Users
 		SingleUser       bool `ini:"single_user"`

--- a/less/core.less
+++ b/less/core.less
@@ -421,7 +421,7 @@ nav#full-nav {
 	}
 }
 
-nav#full-nav a.simple-btn {
+nav#full-nav a.simple-btn, .tool button {
 	font-family: @sansFont;
 	border: 1px solid #ccc !important;
 	padding: .5rem 1rem;

--- a/less/core.less
+++ b/less/core.less
@@ -405,6 +405,31 @@ body {
 	}
 }
 
+nav#full-nav {
+	margin: 0;
+
+	.left-side {
+		display: inline-block;
+
+		a:first-child {
+			margin-left: 0;
+		}
+	}
+
+	.right-side {
+		float: right;
+	}
+}
+
+nav#full-nav a.simple-btn {
+	font-family: @sansFont;
+	border: 1px solid #ccc !important;
+	padding: .5rem 1rem;
+	margin: 0;
+	.rounded(.25em);
+	text-decoration: none;
+}
+
 .post-title {
 	a {
 		&:link {

--- a/less/pad-theme.less
+++ b/less/pad-theme.less
@@ -63,7 +63,7 @@ body#pad, body#pad-sub {
 				}
 			}
 			#belt {
-				a {
+				a, button {
 					color: #000;
 				}
 			}
@@ -100,7 +100,7 @@ body#pad, body#pad-sub {
 				}
 			}
 			#belt {
-				a {
+				a, button {
 					color: white;
 				}
 			}

--- a/less/pad.less
+++ b/less/pad.less
@@ -222,6 +222,13 @@ body#pad, body#pad-sub {
 					font-style: italic;
 				}
 			}
+			button {
+				font-family: @sansFont;
+				background-color: transparent;
+				padding-top: 0.25rem;
+				padding-bottom: 0.25rem;
+				border: 0;
+			}
 		}
 	}
 }

--- a/pad.go
+++ b/pad.go
@@ -53,7 +53,10 @@ func handleViewPad(app *App, w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	padTmpl := "pad"
+	padTmpl := app.cfg.App.Editor
+	if padTmpl == "" {
+		padTmpl = "pad"
+	}
 
 	if action == "" && slug == "" {
 		// Not editing any post; simply render the Pad

--- a/templates/bare.tmpl
+++ b/templates/bare.tmpl
@@ -1,0 +1,235 @@
+{{define "pad"}}<!DOCTYPE HTML>
+<html>
+	<head>
+
+		<title>{{if .Editing}}Editing {{if .Post.Title}}{{.Post.Title}}{{else}}{{.Post.Id}}{{end}}{{else}}New Post{{end}} &mdash; {{.SiteName}}</title>
+		
+		<link rel="stylesheet" type="text/css" href="/css/write.css" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+		<meta name="google" value="notranslate">
+	</head>
+	<body id="pad" class="light">
+
+		<div id="overlay"></div>
+		
+		<textarea id="writer" placeholder="Write..." class="{{.Post.Font}}" autofocus>{{if .Post.Title}}# {{.Post.Title}}
+
+{{end}}{{.Post.Content}}</textarea>
+		
+		<header id="tools">
+			<div id="clip">
+				{{if not .SingleUser}}<h1><a href="/me/c/" title="View blogs">{{.SiteName}}</a></h1>{{end}}
+				<nav id="target" {{if .SingleUser}}style="margin-left:0"{{end}}><ul>
+						<li>{{if .Blogs}}<a href="{{$c := index .Blogs 0}}{{$c.CanonicalURL}}">My Posts</a>{{else}}<a>Draft</a>{{end}}</li>
+				</ul></nav>
+				<span id="wc" class="hidden if-room room-4">0 words</span>
+			</div>
+			<noscript style="margin-left: 2em;"><strong>NOTE</strong>: for now, you'll need Javascript enabled to post.</noscript>
+			<div id="belt">
+				{{if .Editing}}<div class="tool hidden if-room"><a href="{{if .EditCollection}}{{.EditCollection.CanonicalURL}}{{.Post.Slug}}/edit/meta{{else}}/{{if .SingleUser}}d/{{end}}{{.Post.Id}}/meta{{end}}" title="Edit post metadata" id="edit-meta"><img class="ic-24dp" src="/img/ic_info_dark@2x.png" /></a></div>{{end}}
+				<div class="tool"><button title="Publish your writing" id="publish" style="font-weight: bold">Post</button></div>
+			</div>
+		</header>
+
+		<script src="/js/h.js"></script>
+		<script>
+		var $writer = H.getEl('writer');
+		var $btnPublish = H.getEl('publish');
+		var $wc = H.getEl("wc");
+		var updateWordCount = function() {
+			var words = 0;
+			var val = $writer.el.value.trim();
+			if (val != '') {
+				words = $writer.el.value.trim().replace(/\s+/gi, ' ').split(' ').length;
+			}
+			$wc.el.innerText = words + " word" + (words != 1 ? "s" : "");
+		};
+		var setButtonStates = function() {
+			if (!canPublish) {
+				$btnPublish.el.className = 'disabled';
+				return;
+			}
+			if ($writer.el.value.length === 0 || (draftDoc != 'lastDoc' && $writer.el.value == origDoc)) {
+				$btnPublish.el.className = 'disabled';
+			} else {
+				$btnPublish.el.className = '';
+			}
+		};
+		{{if .Post.Id}}var draftDoc = 'draft{{.Post.Id}}';
+		var origDoc = '{{.Post.Content}}';{{else}}var draftDoc = 'lastDoc';{{end}}
+		H.load($writer, draftDoc, true);
+		updateWordCount();
+		
+		var typingTimer;
+		var doneTypingInterval = 200;
+
+		var posts;
+		{{if and .Post.Id (not .Post.Slug)}}
+		var token = null;
+		var curPostIdx;
+		posts = JSON.parse(H.get('posts', '[]'));
+		for (var i=0; i<posts.length; i++) {
+			if (posts[i].id == "{{.Post.Id}}") {
+				token = posts[i].token;
+				break;
+			}
+		}
+		var canPublish = token != null;
+		{{else}}var canPublish = true;{{end}}
+		var publishing = false;
+		var justPublished = false;
+
+		var publish = function(content, font) {
+			{{if and (and .Post.Id (not .Post.Slug)) (not .User)}}
+			if (!token) {
+				alert("You don't have permission to update this post.");
+				return;
+			}
+			{{end}}
+			publishing = true;
+			$btnPublish.el.textContent = 'Posting...';
+			$btnPublish.el.disabled = true;
+
+			var http = new XMLHttpRequest();
+			var lang = navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage);
+			lang = lang.substring(0, 2);
+			var post = H.getTitleStrict(content);
+
+			var params = {
+				body: post.content,
+				title: post.title,
+				font: font,
+				lang: lang
+			};
+			{{ if .Post.Slug }}
+			var url = "/api/collections/{{.EditCollection.Alias}}/posts/{{.Post.Id}}";
+			{{ else if .Post.Id }}
+			var url = "/api/posts/{{.Post.Id}}";
+			if (typeof token === 'undefined' || !token) {
+				token = "";
+			}
+			params.token = token;
+			{{ else }}
+			var url = "/api/posts";
+			var postTarget = '{{if .Blogs}}{{$c := index .Blogs 0}}{{$c.Alias}}{{else}}anonymous{{end}}';
+			if (postTarget != 'anonymous') {
+				url = "/api/collections/" + postTarget + "/posts";
+			}
+			{{ end }}
+
+			http.open("POST", url, true);
+
+			// Send the proper header information along with the request
+			http.setRequestHeader("Content-type", "application/json");
+
+			http.onreadystatechange = function() {
+				if (http.readyState == 4) {
+					publishing = false;
+					if (http.status == 200 || http.status == 201) {
+						data = JSON.parse(http.responseText);
+						id = data.data.id;
+						nextURL = '{{if .SingleUser}}/d{{end}}/'+id;
+
+						{{ if not .Post.Id }}
+							// Post created
+							if (postTarget != 'anonymous') {
+							  nextURL = {{if not .SingleUser}}'/'+postTarget+{{end}}'/'+data.data.slug;
+							}
+							editToken = data.data.token;
+
+							{{ if not .User }}if (postTarget == 'anonymous') {
+								// Save the data
+								var posts = JSON.parse(H.get('posts', '[]'));
+
+								{{if .Post.Id}}var newPost = H.createPost("{{.Post.Id}}", token, content);
+								for (var i=0; i<posts.length; i++) {
+									if (posts[i].id == "{{.Post.Id}}") {
+										posts[i].title = newPost.title;
+										posts[i].summary = newPost.summary;
+										break;
+									}
+								}
+								nextURL = "/pad/posts";{{else}}posts.push(H.createPost(id, editToken, content));{{end}}
+
+								H.set('posts', JSON.stringify(posts));
+							}
+							{{ end }}
+						{{ end }}
+
+						justPublished = true;
+						if (draftDoc != 'lastDoc') {
+							H.remove(draftDoc);
+							{{if .Editing}}H.remove('draft{{.Post.Id}}font');{{end}}
+						} else {
+							H.set(draftDoc, '');
+						}
+
+						{{if .EditCollection}}
+						window.location = '{{.EditCollection.CanonicalURL}}{{.Post.Slug}}';
+						{{else}}
+						window.location = nextURL;
+						{{end}}
+					} else {
+						$btnPublish.el.textContent = 'Post';
+						alert("Failed to post. Please try again.");
+					}
+				}
+			}
+			http.send(JSON.stringify(params));
+		};
+
+		setButtonStates();
+		$writer.on('keyup input', function() {
+			setButtonStates();
+			clearTimeout(typingTimer);
+			typingTimer = setTimeout(doneTyping, doneTypingInterval);
+		}, false);
+		$writer.on('keydown', function(e) {
+			clearTimeout(typingTimer);
+			if (e.keyCode == 13 && (e.metaKey || e.ctrlKey)) {
+				$btnPublish.el.click();
+			}
+		});
+		$btnPublish.on('click', function(e) {
+			e.preventDefault();
+			if (!publishing && $writer.el.value) {
+				var content = $writer.el.value;
+				publish(content, selectedFont);
+			}
+		});
+
+		WebFontConfig = {
+			custom: { families: [ 'Lora:400,700:latin' ], urls: [ '/css/fonts.css' ] }
+		};
+		var selectedFont = H.get('{{if .Editing}}draft{{.Post.Id}}font{{else}}padFont{{end}}', '{{.Post.Font}}');
+
+		var doneTyping = function() {
+			if (draftDoc == 'lastDoc' || $writer.el.value != origDoc) {
+				H.save($writer, draftDoc);
+				updateWordCount();
+			}
+		};
+		window.addEventListener('beforeunload', function(e) {
+			if (draftDoc != 'lastDoc' && $writer.el.value == origDoc) {
+				H.remove(draftDoc);
+			} else if (!justPublished) {
+				doneTyping();
+			}
+		});
+
+		try {
+		  (function() {
+			var wf=document.createElement('script');
+			wf.src = '/js/webfont.js';
+			wf.type='text/javascript';
+			wf.async='true';
+			var s=document.getElementsByTagName('script')[0];
+			s.parentNode.insertBefore(wf, s);
+		  })();
+		} catch (e) {
+		  // whatevs
+		}
+		</script>
+	</body>
+</html>{{end}}

--- a/templates/base.tmpl
+++ b/templates/base.tmpl
@@ -19,7 +19,7 @@
 				<nav class="tabs">
 					<a href="/about"{{if eq .Path "/about"}} class="selected"{{end}}>About</a>
 					{{if and (and (not .SingleUser) .LocalTimeline) .CanViewReader}}<a href="/read"{{if eq .Path "/read"}} class="selected"{{end}}>Reader</a>{{end}}
-					{{if and (not .SingleUser) (not .Username)}}<a href="/login"{{if eq .Path "/login"}} class="selected"{{end}}>Log in</a>{{end}}
+					{{if and (not .SingleUser) (not .Username)}}<a href="/login"{{if eq .Path "/login"}} class="selected"{{end}}>Log in</a>{{else if .SimpleNav}}<a href="/me/logout">Log out</a>{{end}}
 				</nav>
 			</nav>
 			{{end}}

--- a/templates/collection.tmpl
+++ b/templates/collection.tmpl
@@ -48,6 +48,7 @@
 					{{else}}
 					<li><a href="/#{{.Alias}}" class="write">{{.SiteName}}</a></li>
 					{{end}}
+					{{if .SimpleNav}}<li><a href="/new#{{.Alias}}">New Post</a></li>{{end}}
 					<li><a href="/me/c/{{.Alias}}">Customize</a></li>
 					<li><a href="/me/c/{{.Alias}}/stats">Stats</a></li>
 					<li class="separator"><hr /></li>

--- a/templates/user/include/header.tmpl
+++ b/templates/user/include/header.tmpl
@@ -38,7 +38,13 @@
 			</nav>
 		</nav>
 		{{else}}
-		<h1><a href="/" title="Return to editor">{{.SiteName}}</a></h1>
+		{{ if .SimpleNav }}<nav id="full-nav">
+			<div class="left-side">
+				<h1><a href="/" title="Return to editor">{{.SiteName}}</a></h1>
+			</div>
+		{{ else }}
+			<h1><a href="/" title="Return to editor">{{.SiteName}}</a></h1>
+		{{ end }}
 		<nav id="user-nav">
 			<nav class="dropdown-nav">
 				<ul><li><a>{{.Username}}</a> <img class="ic-18dp" src="/img/ic_down_arrow_dark@2x.png" /><ul>
@@ -52,10 +58,21 @@
 				</ul>
 			</nav>
 			<nav class="tabs">
-				<a href="/me/c/"{{if eq .Path "/me/c/"}} class="selected"{{end}}>Blogs</a>
-				<a href="/me/posts/"{{if eq .Path "/me/posts/"}} class="selected"{{end}}>Drafts</a>
+				{{if .SimpleNav}}
+					<a href="/about">About</a>
+					{{if and (and (not .SingleUser) .LocalTimeline) .CanViewReader}}<a href="/read">Reader</a>{{end}}
+					<a href="/me/logout">Log out</a>
+				{{else}}
+					<a href="/me/c/"{{if eq .Path "/me/c/"}} class="selected"{{end}}>Blogs</a>
+					<a href="/me/posts/"{{if eq .Path "/me/posts/"}} class="selected"{{end}}>Drafts</a>
+				{{end}}
 			</nav>
 		</nav>
+		{{if .SimpleNav}}<div class="right-side">
+					<a class="simple-btn" href="/new">New Post</a>
+				</div>
+			</nav>
+		{{end}}
 		{{end}}
 	</header>
 	<div id="official-writing">


### PR DESCRIPTION
This adds a new editor template that strips away most of the customization features in the default editor and includes only:

- publishing
- editing
- viewing word count

It also restricts publishing to a user's first collection, so it's optimized for instances that only allow users to have a single collection and don't use Drafts. To enable, an admin will set the `editor` config value in the `[app]` section to `bare`.

This builds on the work of #153 and #154. It's a work in progress and very experimental.