### PR TITLE
fix tar bombs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GOBUILD=$(GOCMD) build $(LDFLAGS)
 GOTEST=$(GOCMD) test $(LDFLAGS)
 GOGET=$(GOCMD) get
 BINARY_NAME=writefreely
+TAR_NAME=$(BINARY_NAME)_$(GITREV)
 DOCKERCMD=docker
 IMAGE_NAME=writeas/writefreely
 TMPBIN=./tmp
@@ -69,39 +70,40 @@ install : build
 	cd less/; $(MAKE) install $(MFLAGS)
 
 release : clean ui assets
-	mkdir build
-	cp -r templates build
-	cp -r pages build
-	cp -r static build
-	mkdir build/keys
+	mkdir -p build/$(TAR_NAME)
+	cp -r templates build/$(TAR_NAME)
+	cp -r pages build/$(TAR_NAME)
+	cp -r static build/$(TAR_NAME)
+	mkdir build/$(TAR_NAME)/keys
 	$(MAKE) build-linux
-	mv build/$(BINARY_NAME)-linux-amd64 build/$(BINARY_NAME)
-	cd build; tar -cvzf ../$(BINARY_NAME)_$(GITREV)_linux_amd64.tar.gz *
-	rm build/$(BINARY_NAME)
+	mv build/$(BINARY_NAME)-linux-amd64 build/$(TAR_NAME)/$(BINARY_NAME)
+	tar -cvzf $(TAR_NAME)_linux_amd64.tar.gz -C build $(TAR_NAME)
+	rm build/$(TAR_NAME)/$(BINARY_NAME)
 	$(MAKE) build-arm7
-	mv build/$(BINARY_NAME)-linux-arm-7 build/$(BINARY_NAME)
-	cd build; tar -cvzf ../$(BINARY_NAME)_$(GITREV)_linux_arm7.tar.gz *
-	rm build/$(BINARY_NAME)
+	mv build/$(BINARY_NAME)-linux-arm-7 build/$(TAR_NAME)/$(BINARY_NAME)
+	tar -cvzf $(TAR_NAME)_linux_arm7.tar.gz -C build $(TAR_NAME)
+	rm build/$(TAR_NAME)/$(BINARY_NAME)
 	$(MAKE) build-darwin
-	mv build/$(BINARY_NAME)-darwin-10.6-amd64 build/$(BINARY_NAME)
-	cd build; tar -cvzf ../$(BINARY_NAME)_$(GITREV)_macos_amd64.tar.gz *
-	rm build/$(BINARY_NAME)
+	mv build/$(BINARY_NAME)-darwin-10.6-amd64 build/$(TAR_NAME)/$(BINARY_NAME)
+	tar -cvzf $(TAR_NAME)_macos_amd64.tar.gz -C build $(TAR_NAME)
+	rm build/$(TAR_NAME)/$(BINARY_NAME)
 	$(MAKE) build-windows
-	mv build/$(BINARY_NAME)-windows-4.0-amd64.exe build/$(BINARY_NAME).exe
-	cd build; zip -r ../$(BINARY_NAME)_$(GITREV)_windows_amd64.zip ./*
+	mv build/$(BINARY_NAME)-windows-4.0-amd64.exe build/$(TAR_NAME)/$(BINARY_NAME).exe
+	cd build; zip -r ../$(TAR_NAME)_windows_amd64.zip ./$(TAR_NAME)
+	rm build/$(TAR_NAME)/$(BINARY_NAME)
 	$(MAKE) build-docker
 	$(MAKE) release-docker
 
 # This assumes you're on linux/amd64
 release-linux : clean ui
-	mkdir build
-	cp -r templates build
-	cp -r pages build
-	cp -r static build
-	mkdir build/keys
+	mkdir -p build/$(TAR_NAME)
+	cp -r templates build/$(TAR_NAME)
+	cp -r pages build/$(TAR_NAME)
+	cp -r static build/$(TAR_NAME)
+	mkdir build/$(TAR_NAME)/keys
 	$(MAKE) build-no-sqlite
-	mv cmd/writefreely/$(BINARY_NAME) build/$(BINARY_NAME)
-	cd build; tar -cvzf ../$(BINARY_NAME)_$(GITREV)_linux_amd64.tar.gz *
+	mv cmd/writefreely/$(BINARY_NAME) build/$(TAR_NAME)/$(BINARY_NAME)
+	tar -cvzf $(TAR_NAME)_linux_amd64.tar.gz -C build $(TAR_NAME)
 
 release-docker :
 	$(DOCKERCMD) push $(IMAGE_NAME)

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ release : clean ui assets
 	mkdir $(BUILDPATH)/keys
 	$(MAKE) build-linux
 	mv build/$(BINARY_NAME)-linux-amd64 $(BUILDPATH)/$(BINARY_NAME)
-	tar -cvzf $(BINARY_NAME)_$(GIT_REV)_linux_amd64.tar.gz -C build $(BINARY_NAME)
+	tar -cvzf $(BINARY_NAME)_$(GITREV)_linux_amd64.tar.gz -C build $(BINARY_NAME)
 	rm $(BUILDPATH)/$(BINARY_NAME)
 	$(MAKE) build-arm7
 	mv build/$(BINARY_NAME)-linux-arm-7 $(BUILDPATH)/$(BINARY_NAME)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOBUILD=$(GOCMD) build $(LDFLAGS)
 GOTEST=$(GOCMD) test $(LDFLAGS)
 GOGET=$(GOCMD) get
 BINARY_NAME=writefreely
-TAR_NAME=$(BINARY_NAME)_$(GITREV)
+BUILDPATH=build/$(BINARY_NAME)
 DOCKERCMD=docker
 IMAGE_NAME=writeas/writefreely
 TMPBIN=./tmp
@@ -70,40 +70,40 @@ install : build
 	cd less/; $(MAKE) install $(MFLAGS)
 
 release : clean ui assets
-	mkdir -p build/$(TAR_NAME)
-	cp -r templates build/$(TAR_NAME)
-	cp -r pages build/$(TAR_NAME)
-	cp -r static build/$(TAR_NAME)
-	mkdir build/$(TAR_NAME)/keys
+	mkdir -p $(BUILDPATH)
+	cp -r templates $(BUILDPATH)
+	cp -r pages $(BUILDPATH)
+	cp -r static $(BUILDPATH)
+	mkdir $(BUILDPATH)/keys
 	$(MAKE) build-linux
-	mv build/$(BINARY_NAME)-linux-amd64 build/$(TAR_NAME)/$(BINARY_NAME)
-	tar -cvzf $(TAR_NAME)_linux_amd64.tar.gz -C build $(TAR_NAME)
-	rm build/$(TAR_NAME)/$(BINARY_NAME)
+	mv build/$(BINARY_NAME)-linux-amd64 $(BUILDPATH)/$(BINARY_NAME)
+	tar -cvzf $(BINARY_NAME)_$(GIT_REV)_linux_amd64.tar.gz -C build $(BINARY_NAME)
+	rm $(BUILDPATH)/$(BINARY_NAME)
 	$(MAKE) build-arm7
-	mv build/$(BINARY_NAME)-linux-arm-7 build/$(TAR_NAME)/$(BINARY_NAME)
-	tar -cvzf $(TAR_NAME)_linux_arm7.tar.gz -C build $(TAR_NAME)
-	rm build/$(TAR_NAME)/$(BINARY_NAME)
+	mv build/$(BINARY_NAME)-linux-arm-7 $(BUILDPATH)/$(BINARY_NAME)
+	tar -cvzf $(BINARY_NAME)_$(GITREV)_linux_arm7.tar.gz -C build $(BINARY_NAME)
+	rm $(BUILDPATH)/$(BINARY_NAME)
 	$(MAKE) build-darwin
-	mv build/$(BINARY_NAME)-darwin-10.6-amd64 build/$(TAR_NAME)/$(BINARY_NAME)
-	tar -cvzf $(TAR_NAME)_macos_amd64.tar.gz -C build $(TAR_NAME)
-	rm build/$(TAR_NAME)/$(BINARY_NAME)
+	mv build/$(BINARY_NAME)-darwin-10.6-amd64 $(BUILDPATH)/$(BINARY_NAME)
+	tar -cvzf $(BINARY_NAME)_$(GITREV)_macos_amd64.tar.gz -C build $(BINARY_NAME)
+	rm $(BUILDPATH)/$(BINARY_NAME)
 	$(MAKE) build-windows
-	mv build/$(BINARY_NAME)-windows-4.0-amd64.exe build/$(TAR_NAME)/$(BINARY_NAME).exe
-	cd build; zip -r ../$(TAR_NAME)_windows_amd64.zip ./$(TAR_NAME)
-	rm build/$(TAR_NAME)/$(BINARY_NAME)
+	mv build/$(BINARY_NAME)-windows-4.0-amd64.exe $(BUILDPATH)/$(BINARY_NAME).exe
+	cd build; zip -r ../$(BINARY_NAME)_$(GITREV)_windows_amd64.zip ./$(BINARY_NAME)
+	rm $(BUILDPATH)/$(BINARY_NAME)
 	$(MAKE) build-docker
 	$(MAKE) release-docker
 
 # This assumes you're on linux/amd64
-release-linux : clean ui
-	mkdir -p build/$(TAR_NAME)
-	cp -r templates build/$(TAR_NAME)
-	cp -r pages build/$(TAR_NAME)
-	cp -r static build/$(TAR_NAME)
-	mkdir build/$(TAR_NAME)/keys
+release-linux : clean
+	mkdir -p $(BUILDPATH)
+	cp -r templates $(BUILDPATH)
+	cp -r pages $(BUILDPATH)
+	cp -r static $(BUILDPATH)
+	mkdir $(BUILDPATH)/keys
 	$(MAKE) build-no-sqlite
-	mv cmd/writefreely/$(BINARY_NAME) build/$(TAR_NAME)/$(BINARY_NAME)
-	tar -cvzf $(TAR_NAME)_linux_amd64.tar.gz -C build $(TAR_NAME)
+	mv cmd/writefreely/$(BINARY_NAME) $(BUILDPATH)/$(BINARY_NAME)
+	tar -cvzf $(BINARY_NAME)_$(GITREV)_linux_amd64.tar.gz -C build $(BINARY_NAME)
 
 release-docker :
 	$(DOCKERCMD) push $(IMAGE_NAME)

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ release : clean ui assets
 	$(MAKE) release-docker
 
 # This assumes you're on linux/amd64
-release-linux : clean
+release-linux : clean ui
 	mkdir -p $(BUILDPATH)
 	cp -r templates $(BUILDPATH)
 	cp -r pages $(BUILDPATH)

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/writeas/slug v1.2.0
 	github.com/writeas/web-core v1.0.0
 	github.com/writefreely/go-nodeinfo v1.2.0
-	golang.org/x/crypto v0.0.0-20190208162236-193df9c0f06f // indirect
+	golang.org/x/crypto v0.0.0-20190208162236-193df9c0f06f
 	golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1 // indirect
 	golang.org/x/net v0.0.0-20190206173232-65e2d4e15006 // indirect
 	golang.org/x/sys v0.0.0-20190209173611-3b5209105503 // indirect


### PR DESCRIPTION
this changes the release targets in the Makefile to use a subdirectory
of the format BINARYNAME_GITREV so extracting the archive results in a
single directory.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)

closes #160 