### PR TITLE
check for lessc executable in any location

### DIFF
--- a/less/Makefile
+++ b/less/Makefile
@@ -1,9 +1,11 @@
 CSSDIR=../static/css/
 
 all :
-	ifeq (,$(shell command -v lessc 2> /dev/null))
-	$(error "less is not installed, please run install-less.sh")
-	endif
+ifeq (,$(shell command -v lessc 2> /dev/null))
+$(error "less is not installed, please run install-less.sh")
+endif
+	lessc app.less --clean-css="--s1 --advanced" $(CSSDIR)write.css
+	lessc fonts.less --clean-css="--s1 --advanced" $(CSSDIR)fonts.css
 	lessc icons.less --clean-css="--s1 --advanced" $(CSSDIR)icons.css
 
 install :

--- a/less/Makefile
+++ b/less/Makefile
@@ -1,7 +1,7 @@
 CSSDIR=../static/css/
 
 all :
-	@command -v lessc >/dev/null 2>&1 || { echo >&2 "less is not installed, please run install-less.sh."; exit 1; }
+	@command -v lessc >/dev/null 2>&1 || { echo >&2 "lessc is not installed, please run: make install or: less/install-less.sh"; exit 1; }
 	lessc app.less --clean-css="--s1 --advanced" $(CSSDIR)write.css
 	lessc fonts.less --clean-css="--s1 --advanced" $(CSSDIR)fonts.css
 	lessc icons.less --clean-css="--s1 --advanced" $(CSSDIR)icons.css

--- a/less/Makefile
+++ b/less/Makefile
@@ -1,13 +1,8 @@
-ifeq ($(shell which lessc),/usr/bin/lessc)
-	LESSC=/usr/bin/lessc
-else ifeq ($(shell which lessc),/usr/local/bin/lessc)
-	LESSC=/usr/local/bin/lessc
-else ifeq ($(shell which lessc),/bin/lessc)
-	LESSC=/bin/lessc
-else
-	LESSC=node_modules/.bin/lessc
+LESSC := $(shell command -v lessc 2> /dev/null)
+
+ifndef LESSC
+	$(error "less is not installed, please run install-less.sh")
 endif
-export LESSC
 
 CSSDIR=../static/css/
 

--- a/less/Makefile
+++ b/less/Makefile
@@ -1,15 +1,13 @@
-LESSC=$(shell command -v lessc 2> /dev/null)
-
-ifndef LESSC
-	$(error "less is not installed, please run install-less.sh")
+ifeq (,$(shell command -v lessc 2> /dev/null))
+$(error "less is not installed, please run install-less.sh")
 endif
 
 CSSDIR=../static/css/
 
 all :
-	$(LESSC) app.less --clean-css="--s1 --advanced" $(CSSDIR)write.css
-	$(LESSC) fonts.less --clean-css="--s1 --advanced" $(CSSDIR)fonts.css
-	$(LESSC) icons.less --clean-css="--s1 --advanced" $(CSSDIR)icons.css
+	lessc app.less --clean-css="--s1 --advanced" $(CSSDIR)write.css
+	lessc fonts.less --clean-css="--s1 --advanced" $(CSSDIR)fonts.css
+	lessc icons.less --clean-css="--s1 --advanced" $(CSSDIR)icons.css
 
 install :
 	./install-less.sh

--- a/less/Makefile
+++ b/less/Makefile
@@ -1,4 +1,4 @@
-LESSC := $(shell command -v lessc 2> /dev/null)
+LESSC=$(shell command -v lessc 2> /dev/null)
 
 ifndef LESSC
 	$(error "less is not installed, please run install-less.sh")

--- a/less/Makefile
+++ b/less/Makefile
@@ -1,9 +1,7 @@
 CSSDIR=../static/css/
 
 all :
-ifeq (,$(shell command -v lessc 2> /dev/null))
-$(error "less is not installed, please run install-less.sh")
-endif
+	@command -v lessc >/dev/null 2>&1 || { echo >&2 "less is not installed, please run install-less.sh."; exit 1; }
 	lessc app.less --clean-css="--s1 --advanced" $(CSSDIR)write.css
 	lessc fonts.less --clean-css="--s1 --advanced" $(CSSDIR)fonts.css
 	lessc icons.less --clean-css="--s1 --advanced" $(CSSDIR)icons.css

--- a/less/Makefile
+++ b/less/Makefile
@@ -1,12 +1,9 @@
-ifeq (,$(shell command -v lessc 2> /dev/null))
-$(error "less is not installed, please run install-less.sh")
-endif
-
 CSSDIR=../static/css/
 
 all :
-	lessc app.less --clean-css="--s1 --advanced" $(CSSDIR)write.css
-	lessc fonts.less --clean-css="--s1 --advanced" $(CSSDIR)fonts.css
+	ifeq (,$(shell command -v lessc 2> /dev/null))
+	$(error "less is not installed, please run install-less.sh")
+	endif
 	lessc icons.less --clean-css="--s1 --advanced" $(CSSDIR)icons.css
 
 install :


### PR DESCRIPTION
previously the checks were explicit locations which does not work when
using something like nvm to manage node packages and versions.

this checks for the executable and sets the script variable LESSC to the
full path of the one found.
if none was found the make command will error.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
