### PR TITLE
fix panic on duplicate remoteuser key

### DIFF
--- a/activitypub.go
+++ b/activitypub.go
@@ -375,11 +375,11 @@ func handleFetchCollectionInbox(app *App, w http.ResponseWriter, r *http.Request
 				// Add follower locally, since it wasn't found before
 				res, err := t.Exec("INSERT INTO remoteusers (actor_id, inbox, shared_inbox) VALUES (?, ?, ?)", fullActor.ID, fullActor.Inbox, fullActor.Endpoints.SharedInbox)
 				if err != nil {
-					if !app.db.isDuplicateKeyErr(err) {
-						t.Rollback()
-						log.Error("Couldn't add new remoteuser in DB: %v\n", err)
-						return
-					}
+					// if duplicate key, res will be nil and panic on
+					// res.LastInsertId below
+					t.Rollback()
+					log.Error("Couldn't add new remoteuser in DB: %v\n", err)
+					return
 				}
 
 				followerID, err = res.LastInsertId()


### PR DESCRIPTION
this changes handleFetchCollectionInbox to log _all_ errors after
attempting to insert an actor in the remoteusers table. previously
checking for all errors _except_ duplicate keys would cause a panic if
an actor made a request to follow while already having followed.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)

closes #159
