### PR TITLE
Emit the server software and version to the log on startup

### DIFF
--- a/app.go
+++ b/app.go
@@ -486,9 +486,14 @@ func ConnectToDatabase(app *App) error {
 	return nil
 }
 
+// FormatVersion constructs the version string for the application
+func FormatVersion() string {
+	return serverSoftware + " " + softwareVer
+}
+
 // OutputVersion prints out the version of the application.
 func OutputVersion() {
-	fmt.Println(serverSoftware + " " + softwareVer)
+	fmt.Println(FormatVersion())
 }
 
 // NewApp creates a new app instance.

--- a/cmd/writefreely/main.go
+++ b/cmd/writefreely/main.go
@@ -113,6 +113,7 @@ func main() {
 
 	// Initialize the application
 	var err error
+	log.Info("Starting %s...", writefreely.FormatVersion())
 	app, err = writefreely.Initialize(app, *debugPtr)
 	if err != nil {
 		log.Error("%s", err)


### PR DESCRIPTION
As suggested (by me) in https://discuss.write.as/t/log-the-writefreely-version-on-startup/763

This follows the same format as `writefreely -v`, so also refactors `OutputVersion()` to use a new `FormatVersion()` function.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
