### PR TITLE
fix missing collection hostname

### DIFF
--- a/account.go
+++ b/account.go
@@ -13,6 +13,13 @@ package writefreely
 import (
 	"encoding/json"
 	"fmt"
+	"html/template"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 	"github.com/guregu/null/zero"
@@ -22,12 +29,6 @@ import (
 	"github.com/writeas/web-core/log"
 	"github.com/writeas/writefreely/author"
 	"github.com/writeas/writefreely/page"
-	"html/template"
-	"net/http"
-	"regexp"
-	"strings"
-	"sync"
-	"time"
 )
 
 type (
@@ -546,7 +547,7 @@ func getVerboseAuthUser(app *App, token string, u *User, verbose bool) *AuthUser
 		if err != nil {
 			log.Error("Login: Unable to get user posts: %v", err)
 		}
-		colls, err := app.db.GetCollections(u)
+		colls, err := app.db.GetCollections(u, app.cfg.App.Host)
 		if err != nil {
 			log.Error("Login: Unable to get user collections: %v", err)
 		}
@@ -716,7 +717,7 @@ func viewMyCollectionsAPI(app *App, u *User, w http.ResponseWriter, r *http.Requ
 		return ErrBadRequestedType
 	}
 
-	p, err := app.db.GetCollections(u)
+	p, err := app.db.GetCollections(u, app.cfg.App.Host)
 	if err != nil {
 		return err
 	}
@@ -739,7 +740,7 @@ func viewArticles(app *App, u *User, w http.ResponseWriter, r *http.Request) err
 		log.Error("unable to fetch flashes: %v", err)
 	}
 
-	c, err := app.db.GetPublishableCollections(u)
+	c, err := app.db.GetPublishableCollections(u, app.cfg.App.Host)
 	if err != nil {
 		log.Error("unable to fetch collections: %v", err)
 	}
@@ -762,7 +763,7 @@ func viewArticles(app *App, u *User, w http.ResponseWriter, r *http.Request) err
 }
 
 func viewCollections(app *App, u *User, w http.ResponseWriter, r *http.Request) error {
-	c, err := app.db.GetCollections(u)
+	c, err := app.db.GetCollections(u, app.cfg.App.Host)
 	if err != nil {
 		log.Error("unable to fetch collections: %v", err)
 		return fmt.Errorf("No collections")

--- a/admin.go
+++ b/admin.go
@@ -13,16 +13,17 @@ package writefreely
 import (
 	"database/sql"
 	"fmt"
+	"net/http"
+	"runtime"
+	"strconv"
+	"time"
+
 	"github.com/gogits/gogs/pkg/tool"
 	"github.com/gorilla/mux"
 	"github.com/writeas/impart"
 	"github.com/writeas/web-core/auth"
 	"github.com/writeas/web-core/log"
 	"github.com/writeas/writefreely/config"
-	"net/http"
-	"runtime"
-	"strconv"
-	"time"
 )
 
 var (
@@ -195,7 +196,7 @@ func handleViewAdminUser(app *App, u *User, w http.ResponseWriter, r *http.Reque
 		p.LastPost = lp.Format("January 2, 2006, 3:04 PM")
 	}
 
-	colls, err := app.db.GetCollections(p.User)
+	colls, err := app.db.GetCollections(p.User, app.cfg.App.Host)
 	if err != nil {
 		return impart.HTTPError{http.StatusInternalServerError, fmt.Sprintf("Could not get user's collections: %v", err)}
 	}

--- a/collections.go
+++ b/collections.go
@@ -724,6 +724,8 @@ func handleViewCollection(app *App, w http.ResponseWriter, r *http.Request) erro
 		return err
 	}
 
+	c.hostName = app.cfg.App.Host
+
 	// Serve ActivityStreams data now, if requested
 	if strings.Contains(r.Header.Get("Accept"), "application/activity+json") {
 		ac := c.PersonObject()
@@ -762,7 +764,7 @@ func handleViewCollection(app *App, w http.ResponseWriter, r *http.Request) erro
 			owner = u
 			displayPage.CanPin = true
 
-			pubColls, err := app.db.GetPublishableCollections(owner)
+			pubColls, err := app.db.GetPublishableCollections(owner, app.cfg.App.Host)
 			if err != nil {
 				log.Error("unable to fetch collections: %v", err)
 			}
@@ -859,7 +861,7 @@ func handleViewCollectionTag(app *App, w http.ResponseWriter, r *http.Request) e
 			owner = u
 			displayPage.CanPin = true
 
-			pubColls, err := app.db.GetPublishableCollections(owner)
+			pubColls, err := app.db.GetPublishableCollections(owner, app.cfg.App.Host)
 			if err != nil {
 				log.Error("unable to fetch collections: %v", err)
 			}

--- a/database.go
+++ b/database.go
@@ -65,8 +65,8 @@ type writestore interface {
 	ChangeSettings(app *App, u *User, s *userSettings) error
 	ChangePassphrase(userID int64, sudo bool, curPass string, hashedPass []byte) error
 
-	GetCollections(u *User) (*[]Collection, error)
-	GetPublishableCollections(u *User) (*[]Collection, error)
+	GetCollections(u *User, hostName string) (*[]Collection, error)
+	GetPublishableCollections(u *User, hostName string) (*[]Collection, error)
 	GetMeStats(u *User) userMeStats
 	GetTotalCollections() (int64, error)
 	GetTotalPosts() (int64, error)
@@ -1559,7 +1559,7 @@ func (db *datastore) GetPinnedPosts(coll *CollectionObj) (*[]PublicPost, error) 
 	return &posts, nil
 }
 
-func (db *datastore) GetCollections(u *User) (*[]Collection, error) {
+func (db *datastore) GetCollections(u *User, hostName string) (*[]Collection, error) {
 	rows, err := db.Query("SELECT id, alias, title, description, privacy, view_count FROM collections WHERE owner_id = ? ORDER BY id ASC", u.ID)
 	if err != nil {
 		log.Error("Failed selecting from collections: %v", err)
@@ -1575,6 +1575,7 @@ func (db *datastore) GetCollections(u *User) (*[]Collection, error) {
 			log.Error("Failed scanning row: %v", err)
 			break
 		}
+		c.hostName = hostName
 		c.URL = c.CanonicalURL()
 		c.Public = c.IsPublic()
 
@@ -1588,8 +1589,8 @@ func (db *datastore) GetCollections(u *User) (*[]Collection, error) {
 	return &colls, nil
 }
 
-func (db *datastore) GetPublishableCollections(u *User) (*[]Collection, error) {
-	c, err := db.GetCollections(u)
+func (db *datastore) GetPublishableCollections(u *User, hostName string) (*[]Collection, error) {
+	c, err := db.GetCollections(u, hostName)
 	if err != nil {
 		return nil, err
 	}

--- a/export.go
+++ b/export.go
@@ -104,7 +104,7 @@ func compileFullExport(app *App, u *User) *ExportUser {
 		User: u,
 	}
 
-	colls, err := app.db.GetCollections(u)
+	colls, err := app.db.GetCollections(u, app.cfg.App.Host)
 	if err != nil {
 		log.Error("unable to fetch collections: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/writeas/slug v1.2.0
 	github.com/writeas/web-core v1.0.0
 	github.com/writefreely/go-nodeinfo v1.2.0
-	golang.org/x/crypto v0.0.0-20190208162236-193df9c0f06f // indirect
+	golang.org/x/crypto v0.0.0-20190208162236-193df9c0f06f
 	golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1 // indirect
 	golang.org/x/net v0.0.0-20190206173232-65e2d4e15006 // indirect
 	golang.org/x/sys v0.0.0-20190209173611-3b5209105503 // indirect

--- a/pad.go
+++ b/pad.go
@@ -11,12 +11,13 @@
 package writefreely
 
 import (
+	"net/http"
+	"strings"
+
 	"github.com/gorilla/mux"
 	"github.com/writeas/impart"
 	"github.com/writeas/web-core/log"
 	"github.com/writeas/writefreely/page"
-	"net/http"
-	"strings"
 )
 
 func handleViewPad(app *App, w http.ResponseWriter, r *http.Request) error {
@@ -47,7 +48,7 @@ func handleViewPad(app *App, w http.ResponseWriter, r *http.Request) error {
 	}
 	var err error
 	if appData.User != nil {
-		appData.Blogs, err = app.db.GetPublishableCollections(appData.User)
+		appData.Blogs, err = app.db.GetPublishableCollections(appData.User, app.cfg.App.Host)
 		if err != nil {
 			log.Error("Unable to get user's blogs for Pad: %v", err)
 		}

--- a/postrender.go
+++ b/postrender.go
@@ -12,17 +12,18 @@ package writefreely
 
 import (
 	"fmt"
-	"github.com/microcosm-cc/bluemonday"
-	stripmd "github.com/writeas/go-strip-markdown"
-	"github.com/writeas/saturday"
-	"github.com/writeas/web-core/stringmanip"
-	"github.com/writeas/writefreely/parse"
 	"html"
 	"html/template"
 	"regexp"
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/microcosm-cc/bluemonday"
+	stripmd "github.com/writeas/go-strip-markdown"
+	blackfriday "github.com/writeas/saturday"
+	"github.com/writeas/web-core/stringmanip"
+	"github.com/writeas/writefreely/parse"
 )
 
 var (
@@ -36,6 +37,7 @@ var (
 
 func (p *Post) formatContent(c *Collection, isOwner bool) {
 	baseURL := c.CanonicalURL()
+	// TODO: redundant
 	if !isSingleUser {
 		baseURL = "/" + c.Alias + "/"
 	}


### PR DESCRIPTION
GetCollections and GetPublishableCollections now take a hostname
parameter to allow setting the collecion hostname.

All collections used in memory now have their hostname set.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
closes #161