### PR TITLE
Add Cache-Control headers on AP endpoints

### DIFF
--- a/activitypub.go
+++ b/activitypub.go
@@ -37,6 +37,8 @@ import (
 const (
 	// TODO: delete. don't use this!
 	apCustomHandleDefault = "blog"
+
+	apCacheTime = time.Minute
 )
 
 type RemoteUser struct {
@@ -84,6 +86,7 @@ func handleFetchCollectionActivities(app *App, w http.ResponseWriter, r *http.Re
 
 	p := c.PersonObject()
 
+	setCacheControl(w, apCacheTime)
 	return impart.RenderActivityJSON(w, p, http.StatusOK)
 }
 
@@ -137,6 +140,7 @@ func handleFetchCollectionOutbox(app *App, w http.ResponseWriter, r *http.Reques
 		ocp.OrderedItems = append(ocp.OrderedItems, *a)
 	}
 
+	setCacheControl(w, apCacheTime)
 	return impart.RenderActivityJSON(w, ocp, http.StatusOK)
 }
 
@@ -183,6 +187,7 @@ func handleFetchCollectionFollowers(app *App, w http.ResponseWriter, r *http.Req
 			ocp.OrderedItems = append(ocp.OrderedItems, f.ActorID)
 		}
 	*/
+	setCacheControl(w, apCacheTime)
 	return impart.RenderActivityJSON(w, ocp, http.StatusOK)
 }
 
@@ -219,6 +224,7 @@ func handleFetchCollectionFollowing(app *App, w http.ResponseWriter, r *http.Req
 	// Return outbox page
 	ocp := activitystreams.NewOrderedCollectionPage(accountRoot, "following", 0, p)
 	ocp.OrderedItems = []interface{}{}
+	setCacheControl(w, apCacheTime)
 	return impart.RenderActivityJSON(w, ocp, http.StatusOK)
 }
 
@@ -702,4 +708,8 @@ func unmarshalActor(actorResp []byte, actor *activitystreams.Person) error {
 	}(flexActor.Context)
 
 	return nil
+}
+
+func setCacheControl(w http.ResponseWriter, ttl time.Duration) {
+	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%.0f", ttl.Seconds()))
 }

--- a/collections.go
+++ b/collections.go
@@ -730,6 +730,7 @@ func handleViewCollection(app *App, w http.ResponseWriter, r *http.Request) erro
 	if strings.Contains(r.Header.Get("Accept"), "application/activity+json") {
 		ac := c.PersonObject()
 		ac.Context = []interface{}{activitystreams.Namespace}
+		setCacheControl(w, apCacheTime)
 		return impart.RenderActivityJSON(w, ac, http.StatusOK)
 	}
 

--- a/posts.go
+++ b/posts.go
@@ -1034,6 +1034,7 @@ func fetchPost(app *App, w http.ResponseWriter, r *http.Request) error {
 		p.Collection = &CollectionObj{Collection: *coll}
 		po := p.ActivityObject()
 		po.Context = []interface{}{activitystreams.Namespace}
+		setCacheControl(w, apCacheTime)
 		return impart.RenderActivityJSON(w, po, http.StatusOK)
 	}
 
@@ -1359,6 +1360,7 @@ Are you sure it was ever here?`,
 		p.extractData()
 		ap := p.ActivityObject()
 		ap.Context = []interface{}{activitystreams.Namespace}
+		setCacheControl(w, apCacheTime)
 		return impart.RenderActivityJSON(w, ap, http.StatusOK)
 	} else {
 		p.extractData()


### PR DESCRIPTION
This enables future use of Varnish in front of WriteFreely (see [T693](https://writefreely.org/tasks/693) for details).

Includes:

* ActivityPub Collection fetching via canonical URL
* ActivityPub Collection fetching via API
* ActivityPub Post fetching via canonical URL
* ActivityPub Post fetching via API

(By "ActivityPub fetching" I mean requests with the header `Accept: application/activity+json`)

This closes [T693](https://writefreely.org/tasks/693).