### PR TITLE
add user invite instructions

### DIFF
--- a/database.go
+++ b/database.go
@@ -2257,6 +2257,19 @@ func (db *datastore) GetUserInvite(id string) (*Invite, error) {
 	return &i, nil
 }
 
+// IsUsersInvite returns true if the user with ID created the invite with code
+// and an error other than sql no rows, if any. Will return false in the event
+// of an error.
+func (db *datastore) IsUsersInvite(code string, userID int64) (bool, error) {
+	var id string
+	err := db.QueryRow("SELECT id FROM userinvites WHERE id = ? AND owner_id = ?", code, userID).Scan(&id)
+	if err != nil && err != sql.ErrNoRows {
+		log.Error("Failed selecting invite: %v", err)
+		return false, err
+	}
+	return id != "", nil
+}
+
 func (db *datastore) GetUsersInvitedCount(id string) int64 {
 	var count int64
 	err := db.QueryRow("SELECT COUNT(*) FROM usersinvited WHERE invite_id = ?", id).Scan(&count)

--- a/invites.go
+++ b/invites.go
@@ -110,6 +110,11 @@ func handleCreateUserInvite(app *App, u *User, w http.ResponseWriter, r *http.Re
 func handleViewInvite(app *App, w http.ResponseWriter, r *http.Request) error {
 	inviteCode := mux.Vars(r)["code"]
 
+	i, err := app.db.GetUserInvite(inviteCode)
+	if err != nil {
+		return err
+	}
+
 	if u := getUserSession(app, r); u != nil {
 		// check if invite belongs to another user
 		// error can be ignored as not important in this case
@@ -128,11 +133,6 @@ func handleViewInvite(app *App, w http.ResponseWriter, r *http.Request) error {
 		}
 		showUserPage(w, "invite-instructions", p)
 		return nil
-	}
-
-	i, err := app.db.GetUserInvite(inviteCode)
-	if err != nil {
-		return err
 	}
 
 	p := struct {

--- a/invites.go
+++ b/invites.go
@@ -141,7 +141,7 @@ func handleViewInvite(app *App, w http.ResponseWriter, r *http.Request) error {
 			Invite:   i,
 			Expired:  expired,
 		}
-		showUserPage(w, "invite-instructions", p)
+		showUserPage(w, "invite-help", p)
 		return nil
 	}
 

--- a/invites.go
+++ b/invites.go
@@ -137,7 +137,7 @@ func handleViewInvite(app *App, w http.ResponseWriter, r *http.Request) error {
 			InviteID string
 			Expired bool
 		}{
-			UserPage: NewUserPage(app, r, u, "Invite Instructions", nil),
+			UserPage: NewUserPage(app, r, u, "Invite to "+app.cfg.App.SiteName, nil),
 			InviteID: inviteCode,
 			Expired:  expired,
 		}

--- a/invites.go
+++ b/invites.go
@@ -126,7 +126,7 @@ func handleViewInvite(app *App, w http.ResponseWriter, r *http.Request) error {
 		// check if invite belongs to another user
 		// error can be ignored as not important in this case
 		if ownInvite, _ := app.db.IsUsersInvite(inviteCode, u.ID); !ownInvite {
-			addSessionFlash(app, w, r, "No need for an invite, You are already registered.", nil)
+			addSessionFlash(app, w, r, "You're already registered and logged in.", nil)
 			// show homepage
 			return impart.HTTPError{http.StatusFound, "/me/settings"}
 		}

--- a/invites.go
+++ b/invites.go
@@ -134,11 +134,11 @@ func handleViewInvite(app *App, w http.ResponseWriter, r *http.Request) error {
 		// show invite instructions
 		p := struct {
 			*UserPage
-			InviteID string
+			Invite  *Invite
 			Expired bool
 		}{
 			UserPage: NewUserPage(app, r, u, "Invite to "+app.cfg.App.SiteName, nil),
-			InviteID: inviteCode,
+			Invite:   i,
 			Expired:  expired,
 		}
 		showUserPage(w, "invite-instructions", p)

--- a/routes.go
+++ b/routes.go
@@ -11,13 +11,14 @@
 package writefreely
 
 import (
+	"net/http"
+	"path/filepath"
+	"strings"
+
 	"github.com/gorilla/mux"
 	"github.com/writeas/go-webfinger"
 	"github.com/writeas/web-core/log"
 	"github.com/writefreely/go-nodeinfo"
-	"net/http"
-	"path/filepath"
-	"strings"
 )
 
 // InitStaticRoutes adds routes for serving static files.
@@ -151,7 +152,7 @@ func InitRoutes(apper Apper, r *mux.Router) *mux.Router {
 	// Handle special pages first
 	write.HandleFunc("/login", handler.Web(viewLogin, UserLevelNoneRequired))
 	write.HandleFunc("/signup", handler.Web(handleViewLanding, UserLevelNoneRequired))
-	write.HandleFunc("/invite/{code}", handler.Web(handleViewInvite, UserLevelNoneRequired)).Methods("GET")
+	write.HandleFunc("/invite/{code}", handler.Web(handleViewInvite, UserLevelOptional)).Methods("GET")
 	// TODO: show a reader-specific 404 page if the function is disabled
 	write.HandleFunc("/read", handler.Web(viewLocalTimeline, UserLevelReader))
 	RouteRead(handler, UserLevelReader, write.PathPrefix("/read").Subrouter())

--- a/templates/user/invite-help.tmpl
+++ b/templates/user/invite-help.tmpl
@@ -1,4 +1,4 @@
-{{define "invite-instructions"}}
+{{define "invite-help"}}
 {{template "header" .}}
 <style>
   .copy-link {

--- a/templates/user/invite-instructions.tmpl
+++ b/templates/user/invite-instructions.tmpl
@@ -1,0 +1,25 @@
+{{define "invite-instructions"}}
+{{template "header" .}}
+<style>
+  .copy-link {
+    width: 100%;
+    margin: 2em 0;
+    text-align: center;
+    font-size-adjust: .7;
+    color: #555;
+  }
+</style>
+<div class="snug content-container">
+	<h1>Invite Instructions</h1>
+  <p>This is a special link that you can send to anyone you want to join <em>{{ .SiteName }}</em>. Copy the link below and paste it into an email, instant message, or text message and send it to the person you want. When they navigate to the link, they'll be able to create an account.</p>
+  <input
+  class="copy-link"
+  type="text"
+  name="invite-url"
+  value="{{$.Host}}/invite/{{.InviteID}}"
+  onfocus="if (this.select) this.select(); else this.setSelectionRange(0, this.value.length);"
+  readonly/>
+</div>
+
+{{template "footer" .}}
+{{end}}

--- a/templates/user/invite-instructions.tmpl
+++ b/templates/user/invite-instructions.tmpl
@@ -11,14 +11,18 @@
 </style>
 <div class="snug content-container">
 	<h1>Invite Instructions</h1>
-  <p>This is a special link that you can send to anyone you want to join <em>{{ .SiteName }}</em>. Copy the link below and paste it into an email, instant message, or text message and send it to the person you want. When they navigate to the link, they'll be able to create an account.</p>
-  <input
-  class="copy-link"
-  type="text"
-  name="invite-url"
-  value="{{$.Host}}/invite/{{.InviteID}}"
-  onfocus="if (this.select) this.select(); else this.setSelectionRange(0, this.value.length);"
-  readonly/>
+	{{ if .Expired }}
+		<p style="font-style: italic">This invite link is expired.</p>
+	{{ else }}
+		<p>This is a special link that you can send to anyone you want to join <em>{{ .SiteName }}</em>. Copy the link below and paste it into an email, instant message, or text message and send it to the person you want. When they navigate to the link, they'll be able to create an account.</p>
+		<input
+		class="copy-link"
+		type="text"
+		name="invite-url"
+		value="{{$.Host}}/invite/{{.InviteID}}"
+		onfocus="if (this.select) this.select(); else this.setSelectionRange(0, this.value.length);"
+		readonly/>
+	{{ end }}
 </div>
 
 {{template "footer" .}}

--- a/templates/user/invite-instructions.tmpl
+++ b/templates/user/invite-instructions.tmpl
@@ -3,7 +3,7 @@
 <style>
   .copy-link {
     width: 100%;
-    margin: 2em 0;
+    margin: 1em 0;
     text-align: center;
     font-size-adjust: .7;
     color: #555;
@@ -15,7 +15,16 @@
 		<p style="font-style: italic">This invite link is expired.</p>
 	{{ else }}
 		<p>Copy the link below and send it to anyone that you want to join <em>{{ .SiteName }}</em>. You could paste it into an email, instant message, text message, or write it down on paper. Anyone who navigates to this special page will be able to create an account.</p>
-		<input class="copy-link" type="text" name="invite-url" value="{{$.Host}}/invite/{{.InviteID}}" onfocus="if (this.select) this.select(); else this.setSelectionRange(0, this.value.length);" readonly />
+		<input class="copy-link" type="text" name="invite-url" value="{{$.Host}}/invite/{{.Invite.ID}}" onfocus="if (this.select) this.select(); else this.setSelectionRange(0, this.value.length);" readonly />
+		<p>
+			{{ if gt .Invite.MaxUses.Int64 0 }}
+				{{if eq .Invite.MaxUses.Int64 1}}Only <strong>one</strong> user{{else}}Up to <strong>{{.Invite.MaxUses.Int64}}</strong> users{{end}} can sign up with this link.
+				{{if gt .Invite.Uses 0}}So far, <strong>{{.Invite.Uses}}</strong> {{pluralize "person has" "people have" .Invite.Uses}} used it.{{end}}
+				{{if .Invite.Expires}}It expires on <strong>{{.Invite.ExpiresFriendly}}</strong>.{{end}}
+			{{ else }}
+				It can be used as many times as you like{{if .Invite.Expires}} before <strong>{{.Invite.ExpiresFriendly}}</strong>, when it expires{{end}}.
+			{{ end }}
+		</p>
 	{{ end }}
 </div>
 

--- a/templates/user/invite-instructions.tmpl
+++ b/templates/user/invite-instructions.tmpl
@@ -10,18 +10,12 @@
   }
 </style>
 <div class="snug content-container">
-	<h1>Invite Instructions</h1>
+	<h1>Invite to {{.SiteName}}</h1>
 	{{ if .Expired }}
 		<p style="font-style: italic">This invite link is expired.</p>
 	{{ else }}
-		<p>This is a special link that you can send to anyone you want to join <em>{{ .SiteName }}</em>. Copy the link below and paste it into an email, instant message, or text message and send it to the person you want. When they navigate to the link, they'll be able to create an account.</p>
-		<input
-		class="copy-link"
-		type="text"
-		name="invite-url"
-		value="{{$.Host}}/invite/{{.InviteID}}"
-		onfocus="if (this.select) this.select(); else this.setSelectionRange(0, this.value.length);"
-		readonly/>
+		<p>Copy the link below and send it to anyone that you want to join <em>{{ .SiteName }}</em>. You could paste it into an email, instant message, text message, or write it down on paper. Anyone who navigates to this special page will be able to create an account.</p>
+		<input class="copy-link" type="text" name="invite-url" value="{{$.Host}}/invite/{{.InviteID}}" onfocus="if (this.select) this.select(); else this.setSelectionRange(0, this.value.length);" readonly />
 	{{ end }}
 </div>
 

--- a/templates/user/invite-instructions.tmpl
+++ b/templates/user/invite-instructions.tmpl
@@ -3,9 +3,9 @@
 <style>
   .copy-link {
     width: 100%;
-    margin: 1em 0;
+    margin: 1rem 0;
     text-align: center;
-    font-size-adjust: .7;
+    font-size: 1.2em;
     color: #555;
   }
 </style>


### PR DESCRIPTION
this adds a new page with instructions for sharing user invites

if a user clicks the link for one of their own invite codes they are
directed to a page with clear instructions for it's use.

if a user clicks another users link they are redirectec to their account
settings witha flash telling them they do not need to register.

ref [T690](https://writefreely.org/tasks/690)

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
