### PR TITLE
add dates to posts on collections w/ blog format

### DIFF
--- a/less/core.less
+++ b/less/core.less
@@ -86,6 +86,7 @@ body {
 		}
 
 		header {
+			padding: 1em 1rem;
 			nav {
 				span, a {
 					&.pinned {
@@ -101,6 +102,13 @@ body {
 		}
 		.owner-visible {
 			display: none;
+		}
+		time.dt-published {
+			display: block;
+			&.subtle {
+				color: #666;
+				margin-bottom: 0.5em;
+			}
 		}
 	}
 

--- a/less/post-temp.less
+++ b/less/post-temp.less
@@ -59,7 +59,7 @@ body#post article, pre, .hljs {
 	font-size: 1.5em;
 	display: block;
 	margin-top: 0;
-	margin-bottom: 1em;
+	margin-bottom: 0.5em;
 }
 
 .hljs {

--- a/posts.go
+++ b/posts.go
@@ -1380,12 +1380,14 @@ Are you sure it was ever here?`,
 			IsFound        bool
 			IsAdmin        bool
 			CanInvite      bool
+			ShowDates      bool
 		}{
 			PublicPost:     p,
 			StaticPage:     pageForReq(app, r),
 			IsOwner:        cr.isCollOwner,
 			IsCustomDomain: cr.isCustomDomain,
 			IsFound:        postFound,
+			ShowDates:      c.NewFormat().ShowDates(),
 		}
 		tp.IsAdmin = u != nil && u.IsAdmin()
 		tp.CanInvite = canUserInvite(app.cfg, tp.IsAdmin)

--- a/templates/chorus-collection-post.tmpl
+++ b/templates/chorus-collection-post.tmpl
@@ -41,7 +41,7 @@ body#post header {
 article time.dt {
 	display: block;
 }
-article time.dt.published {
+article time.dt.subtle {
 	color: #666;
 	margin-bottom: 1em;
 }
@@ -68,7 +68,7 @@ body#post article h2#title{
 		<article id="post-body" class="{{.Font}} h-entry">
 		{{if .IsScheduled}}<p class="badge">Scheduled</p>{{end}}
 		{{if .Title.String}}<h2 id="title" class="p-name">{{.FormattedDisplayTitle}}</h2>{{end}}
-		{{if .ShowDates}}<time class="dt{{if .Title.String}} published{{end}}" datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</time>{{end}}
+		{{if .ShowDates}}<time class="dt{{if .Title.String}} subtle{{end}}" datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</time>{{end}}
 		<div class="e-content">{{.HTMLContent}}</div></article>
 
 		{{ if .Collection.ShowFooterBranding }}

--- a/templates/chorus-collection-post.tmpl
+++ b/templates/chorus-collection-post.tmpl
@@ -30,26 +30,6 @@
 		{{range .Images}}<meta property="og:image" content="{{.}}" />{{else}}<meta property="og:image" content="{{.Collection.AvatarURL}}">{{end}}
 		<meta property="article:published_time" content="{{.Created8601}}">
 		{{if .Collection.StyleSheet}}<style type="text/css">{{.Collection.StyleSheetDisplay}}</style>{{end}}
-	<style type="text/css">
-body footer {
-	max-width: 40rem;
-	margin: 0 auto;
-}
-body#post header {
-	padding: 1em 1rem;
-}
-article time.dt {
-	display: block;
-}
-article time.dt.subtle {
-	color: #666;
-	margin-bottom: 1em;
-}
-body#post article h2#title{
-	margin-bottom: 0.5em;
-}
-	</style>
-
 		{{if .Collection.RenderMathJax}}
 		  <!-- Add mathjax logic -->
   		  {{template "mathjax" . }}
@@ -68,7 +48,7 @@ body#post article h2#title{
 		<article id="post-body" class="{{.Font}} h-entry">
 		{{if .IsScheduled}}<p class="badge">Scheduled</p>{{end}}
 		{{if .Title.String}}<h2 id="title" class="p-name">{{.FormattedDisplayTitle}}</h2>{{end}}
-		{{if .ShowDates}}<time class="dt{{if .Title.String}} subtle{{end}}" datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</time>{{end}}
+		{{if .ShowDates}}<time class="dt-published{{if .Title.String}} subtle{{end}}" datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</time>{{end}}
 		<div class="e-content">{{.HTMLContent}}</div></article>
 
 		{{ if .Collection.ShowFooterBranding }}

--- a/templates/chorus-collection-post.tmpl
+++ b/templates/chorus-collection-post.tmpl
@@ -38,15 +38,15 @@ body footer {
 body#post header {
 	padding: 1em 1rem;
 }
-article time.dt-published {
+article time.dt {
 	display: block;
+}
+article time.dt.published {
 	color: #666;
+	margin-bottom: 1em;
 }
 body#post article h2#title{
 	margin-bottom: 0.5em;
-}
-article time.dt-published {
-	margin-bottom: 1em;
 }
 	</style>
 
@@ -65,7 +65,11 @@ article time.dt-published {
 
 		{{template "user-navigation" .}}
 		
-		<article id="post-body" class="{{.Font}} h-entry">{{if .IsScheduled}}<p class="badge">Scheduled</p>{{end}}{{if .Title.String}}<h2 id="title" class="p-name">{{.FormattedDisplayTitle}}</h2>{{end}}{{/* TODO: check format: if .Collection.Format.ShowDates*/}}<time class="dt-published" datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</time><div class="e-content">{{.HTMLContent}}</div></article>
+		<article id="post-body" class="{{.Font}} h-entry">
+		{{if .IsScheduled}}<p class="badge">Scheduled</p>{{end}}
+		{{if .Title.String}}<h2 id="title" class="p-name">{{.FormattedDisplayTitle}}</h2>{{end}}
+		{{if .ShowDates}}<time class="dt{{if .Title.String}} published{{end}}" datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</time>{{end}}
+		<div class="e-content">{{.HTMLContent}}</div></article>
 
 		{{ if .Collection.ShowFooterBranding }}
 		<footer dir="ltr">

--- a/templates/collection-post.tmpl
+++ b/templates/collection-post.tmpl
@@ -40,7 +40,7 @@ body#post header {
 article time.dt {
 	display: block;
 }
-article time.dt.published {
+article time.dt.subtle {
 	color: #666;
 	margin-bottom: 1em;
 }
@@ -77,7 +77,7 @@ body#post article h2#title{
 		<article id="post-body" class="{{.Font}} h-entry {{if not .IsFound}}error-page{{end}}">
 		{{if .IsScheduled}}<p class="badge">Scheduled</p>{{end}}
 		{{if .Title.String}}<h2 id="title" class="p-name">{{.FormattedDisplayTitle}}</h2>{{end}}
-		{{if .ShowDates}}<time class="dt{{if .Title.String}} published{{end}}" datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</time>{{end}}
+		{{if .ShowDates}}<time class="dt{{if .Title.String}} subtle{{end}}" datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</time>{{end}}
 		<div class="e-content">{{.HTMLContent}}</div>
 		</article>
 

--- a/templates/collection-post.tmpl
+++ b/templates/collection-post.tmpl
@@ -32,22 +32,6 @@
 		<meta property="article:published_time" content="{{.Created8601}}">
 		{{ end }}
 		{{if .Collection.StyleSheet}}<style type="text/css">{{.Collection.StyleSheetDisplay}}</style>{{end}}
-		{{/*below css duplicated in part in chorus-collection-post.tmpl*/}}
-	<style type="text/css">
-body#post header {
-	padding: 1em 1rem;
-}
-article time.dt {
-	display: block;
-}
-article time.dt.subtle {
-	color: #666;
-	margin-bottom: 1em;
-}
-body#post article h2#title{
-	margin-bottom: 0.5em;
-}
-	</style>
 		{{if .Collection.RenderMathJax}}
 		  <!-- Add mathjax logic -->
   		  {{template "mathjax" . }}
@@ -77,7 +61,7 @@ body#post article h2#title{
 		<article id="post-body" class="{{.Font}} h-entry {{if not .IsFound}}error-page{{end}}">
 		{{if .IsScheduled}}<p class="badge">Scheduled</p>{{end}}
 		{{if .Title.String}}<h2 id="title" class="p-name">{{.FormattedDisplayTitle}}</h2>{{end}}
-		{{if .ShowDates}}<time class="dt{{if .Title.String}} subtle{{end}}" datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</time>{{end}}
+		{{if .ShowDates}}<time class="dt-published{{if .Title.String}} subtle{{end}}" datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</time>{{end}}
 		<div class="e-content">{{.HTMLContent}}</div>
 		</article>
 

--- a/templates/collection-post.tmpl
+++ b/templates/collection-post.tmpl
@@ -32,7 +32,22 @@
 		<meta property="article:published_time" content="{{.Created8601}}">
 		{{ end }}
 		{{if .Collection.StyleSheet}}<style type="text/css">{{.Collection.StyleSheetDisplay}}</style>{{end}}
-
+		{{/*below css duplicated in part in chorus-collection-post.tmpl*/}}
+	<style type="text/css">
+body#post header {
+	padding: 1em 1rem;
+}
+article time.dt {
+	display: block;
+}
+article time.dt.published {
+	color: #666;
+	margin-bottom: 1em;
+}
+body#post article h2#title{
+	margin-bottom: 0.5em;
+}
+	</style>
 		{{if .Collection.RenderMathJax}}
 		  <!-- Add mathjax logic -->
   		  {{template "mathjax" . }}
@@ -59,7 +74,12 @@
 			</nav>
 		</header>
 		
-		<article id="post-body" class="{{.Font}} h-entry {{if not .IsFound}}error-page{{end}}">{{if .IsScheduled}}<p class="badge">Scheduled</p>{{end}}{{if .Title.String}}<h2 id="title" class="p-name">{{.FormattedDisplayTitle}}</h2>{{end}}<div class="e-content">{{.HTMLContent}}</div></article>
+		<article id="post-body" class="{{.Font}} h-entry {{if not .IsFound}}error-page{{end}}">
+		{{if .IsScheduled}}<p class="badge">Scheduled</p>{{end}}
+		{{if .Title.String}}<h2 id="title" class="p-name">{{.FormattedDisplayTitle}}</h2>{{end}}
+		{{if .ShowDates}}<time class="dt{{if .Title.String}} published{{end}}" datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</time>{{end}}
+		<div class="e-content">{{.HTMLContent}}</div>
+		</article>
 
 		{{ if .Collection.ShowFooterBranding }}
 		<footer dir="ltr"><hr><nav><p style="font-size: 0.9em">{{localhtml "published with write.as" .Language.String}}</p></nav></footer>


### PR DESCRIPTION
This adds conditional date placement on collection posts using the 'blog' format.

When dates are shown without a post title, the date is formatted as the body text with top placement.

---

ref T669

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
