### PR TITLE
lightly style tables in posts

### DIFF
--- a/less/core.less
+++ b/less/core.less
@@ -632,6 +632,30 @@ table.classy {
 	}
 }
 
+body#post article table {
+	border-spacing: 0;
+	border-collapse: collapse;
+	th {
+		border-bottom: 2px solid #ccc;
+		text-align: center;
+	}
+	th + th {
+		border-left: 1px solid #ccc;
+	}
+	tr:nth-child(even) {
+		background-color: #f6f6f6;
+	}
+	td + td {
+		border-left: 1px solid #ccc;
+	}
+	tr + tr td {
+		border-top: 1px solid #ccc;
+	}
+	td, th {
+		padding: .25rem .5rem;
+	}
+}
+
 body#collection article, body#subpage article {
 	padding-top: 0;
 	padding-bottom: 0;

--- a/less/core.less
+++ b/less/core.less
@@ -632,26 +632,19 @@ table.classy {
 	}
 }
 
-body#post article table {
+article table {
 	border-spacing: 0;
 	border-collapse: collapse;
+	width: 100%;
 	th {
-		border-bottom: 2px solid #ccc;
-		text-align: center;
+		border-width: 1px 1px 2px 1px;
+		border-style: solid;
+		border-color: #ccc;
 	}
-	th + th {
-		border-left: 1px solid #ccc;
-	}
-	tr:nth-child(even) {
-		background-color: #f6f6f6;
-	}
-	td + td {
-		border-left: 1px solid #ccc;
-	}
-	tr + tr td {
-		border-top: 1px solid #ccc;
-	}
-	td, th {
+	td {
+		border-width: 0 1px 1px 1px;
+		border-style: solid;
+		border-color: #ccc;
 		padding: .25rem .5rem;
 	}
 }


### PR DESCRIPTION
styling added:
- thin inner borders
- table body rows alternate light background
- table header text centered
- cellspacing reset and replaced with padding to avoid gaps in borders

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
