### PR TITLE
Optimized regexp for matching tags.

### DIFF
--- a/database.go
+++ b/database.go
@@ -1187,7 +1187,7 @@ func (db *datastore) GetPostsTagged(cfg *config.Config, c *Collection, tag strin
 	var rows *sql.Rows
 	var err error
 	if db.driverName == driverSQLite {
-		rows, err = db.Query("SELECT "+postCols+" FROM posts WHERE collection_id = ? AND LOWER(content) regexp ? "+timeCondition+" ORDER BY created "+order+limitStr, collID, `.*#`+strings.ToLower(tag)+`\b.*`)
+		rows, err = db.Query("SELECT "+postCols+" FROM posts WHERE collection_id = ? AND LOWER(content) regexp ? "+timeCondition+" ORDER BY created "+order+limitStr, collID, `#`+strings.ToLower(tag)+`([,.!\s]|$)`)
 	} else {
 		rows, err = db.Query("SELECT "+postCols+" FROM posts WHERE collection_id = ? AND LOWER(content) RLIKE ? "+timeCondition+" ORDER BY created "+order+limitStr, collID, "#"+strings.ToLower(tag)+"[[:>:]]")
 	}


### PR DESCRIPTION
A tiny optimization for the SQLite regexp matching removing no-op `.*` before and after the regexp matching tags. I'm not sure if it affects performance noticeably, but it's an inaccurate regexp because `.*` will match anything and doesn't really have to be included.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
