### PR TITLE
add silenced warning on invites page

### DIFF
--- a/invites.go
+++ b/invites.go
@@ -56,12 +56,20 @@ func handleViewUserInvites(app *App, u *User, w http.ResponseWriter, r *http.Req
 
 	p := struct {
 		*UserPage
-		Invites *[]Invite
+		Invites   *[]Invite
+		Suspended bool
 	}{
 		UserPage: NewUserPage(app, r, u, "Invite People", f),
 	}
 
 	var err error
+
+	p.Suspended, err = app.db.IsUserSuspended(u.ID)
+	if err != nil {
+		log.Error("view invites: %v", err)
+		return ErrInternalGeneral
+	}
+
 	p.Invites, err = app.db.GetUserInvites(u.ID)
 	if err != nil {
 		return err

--- a/invites.go
+++ b/invites.go
@@ -67,7 +67,6 @@ func handleViewUserInvites(app *App, u *User, w http.ResponseWriter, r *http.Req
 	p.Suspended, err = app.db.IsUserSuspended(u.ID)
 	if err != nil {
 		log.Error("view invites: %v", err)
-		return ErrInternalGeneral
 	}
 
 	p.Invites, err = app.db.GetUserInvites(u.ID)

--- a/templates/user/invite.tmpl
+++ b/templates/user/invite.tmpl
@@ -41,7 +41,7 @@ table td {
 		<div class="row">
 			<div class="half">
 				<label for="uses">Maximum number of uses:</label>
-				<select id="uses" name="uses">
+				<select id="uses" name="uses" {{if .Suspended}}disabled{{end}}>
 					<option value="0">No limit</option>
 					<option value="1">1 use</option>
 					<option value="5">5 uses</option>
@@ -53,7 +53,7 @@ table td {
 			</div>
 			<div class="half">
 				<label for="expires">Expire after:</label>
-				<select id="expires" name="expires">
+				<select id="expires" name="expires" {{if .Suspended}}disabled{{end}}>
 					<option value="0">Never</option>
 					<option value="30">30 minutes</option>
 					<option value="60">1 hour</option>
@@ -66,7 +66,7 @@ table td {
 			</div>
 		</div>
 		<div class="row">
-			<input type="submit" value="Generate" />
+			<input type="submit" value="Generate" {{if .Suspended}}disabled title="You cannot generate invites while your account is silenced."{{end}} />
 		</div>
 	</form>
 

--- a/templates/user/invite.tmpl
+++ b/templates/user/invite.tmpl
@@ -31,6 +31,9 @@ table td {
 </style>
 
 <div class="snug content-container">
+	{{if .Suspended}}
+		{{template "user-suspended"}}
+	{{end}}
 	<h1>Invite people</h1>
 	<p>Invite others to join <em>{{.SiteName}}</em> by generating and sharing invite links below.</p>
 


### PR DESCRIPTION
This adds the same warnng about a user account being silence on the view invites page as a silenced use can no longer create invites.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
