### PR TITLE
Fix fediverse post IDs

### DIFF
--- a/posts.go
+++ b/posts.go
@@ -1039,7 +1039,6 @@ func pinPost(app *App, w http.ResponseWriter, r *http.Request) error {
 
 func fetchPost(app *App, w http.ResponseWriter, r *http.Request) error {
 	var collID int64
-	var ownerID int64
 	var coll *Collection
 	var err error
 	vars := mux.Vars(r)
@@ -1055,14 +1054,13 @@ func fetchPost(app *App, w http.ResponseWriter, r *http.Request) error {
 			return err
 		}
 		collID = coll.ID
-		ownerID = coll.OwnerID
 	}
 
 	p, err := app.db.GetPost(vars["post"], collID)
 	if err != nil {
 		return err
 	}
-	suspended, err := app.db.IsUserSuspended(ownerID)
+	suspended, err := app.db.IsUserSuspended(p.OwnerID.Int64)
 	if err != nil {
 		log.Error("fetch post: %v", err)
 		return ErrInternalGeneral


### PR DESCRIPTION
Previously, fetching ActivityStreams data about a post via `/api/posts/ID`, instead of `/api/collections/ALIAS/posts/SLUG` wouldn't include the instance's base URL in the post's `id`, causing federation issues. This fixes that.

It also includes the related fix in #212.