### PR TITLE
Suppress log when editing a collection post or its metadata

### DIFF
--- a/pad.go
+++ b/pad.go
@@ -92,6 +92,7 @@ func handleViewPad(app *App, w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
+		appData.EditCollection.hostName = app.cfg.App.Host
 	} else {
 		// Editing a floating article
 		appData.Post = getRawPost(app, action)
@@ -161,6 +162,7 @@ func handleViewMeta(app *App, w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
+		appData.EditCollection.hostName = app.cfg.App.Host
 	} else {
 		// Editing a floating article
 		appData.Post = getRawPost(app, action)


### PR DESCRIPTION
This adds the instance's Hostname to the collection data loaded when editing a collection post or its metadata. While not technically needed in this situation, it suppresses an alarming error log.

Resolves #216