### PR TITLE
Fix password-protected page template

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -648,6 +648,16 @@ func processCollectionPermissions(app *App, cr *collectionReq, u *User, w http.R
 				uname = u.Username
 			}
 
+			// TODO: move this to all permission checks?
+			suspended, err := app.db.IsUserSuspended(c.OwnerID)
+			if err != nil {
+				log.Error("process protected collection permissions: %v", err)
+				return nil, err
+			}
+			if suspended {
+				return nil, ErrCollectionNotFound
+			}
+
 			// See if we've authorized this collection
 			authd := isAuthorizedForCollection(app, c.Alias, r)
 

--- a/posts.go
+++ b/posts.go
@@ -1342,8 +1342,13 @@ func viewCollectionPost(app *App, w http.ResponseWriter, r *http.Request) error 
 	if c.IsPrivate() && (u == nil || u.ID != c.OwnerID) {
 		return ErrPostNotFound
 	}
-	if c.IsProtected() && ((u == nil || u.ID != c.OwnerID) && !isAuthorizedForCollection(app, c.Alias, r)) {
-		return impart.HTTPError{http.StatusFound, c.CanonicalURL() + "/?g=" + slug}
+	if c.IsProtected() && (u == nil || u.ID != c.OwnerID) {
+		if suspended {
+			return ErrPostNotFound
+		} else if !isAuthorizedForCollection(app, c.Alias, r) {
+			return impart.HTTPError{http.StatusFound, c.CanonicalURL() + "/?g=" + slug}
+
+		}
 	}
 
 	cr.isCollOwner = u != nil && c.OwnerID == u.ID

--- a/posts.go
+++ b/posts.go
@@ -1347,7 +1347,6 @@ func viewCollectionPost(app *App, w http.ResponseWriter, r *http.Request) error 
 			return ErrPostNotFound
 		} else if !isAuthorizedForCollection(app, c.Alias, r) {
 			return impart.HTTPError{http.StatusFound, c.CanonicalURL() + "/?g=" + slug}
-
 		}
 	}
 

--- a/templates/edit-meta.tmpl
+++ b/templates/edit-meta.tmpl
@@ -270,7 +270,7 @@
 		<script>
 function updateMeta() {
 	if ({{.Suspended}}) {
-		alert('Your account is currently supsended, editing posts is disabled.');
+		alert("Your account is silenced, so you can't edit posts.");
 		return
 	}
 	document.getElementById('create-error').style.display = 'none';

--- a/templates/password-collection.tmpl
+++ b/templates/password-collection.tmpl
@@ -26,7 +26,7 @@
 	</head>
 	<body id="collection" itemscope itemtype="http://schema.org/WebPage">
 		{{if .Suspended}}
-			{{template "user-supsended"}}
+			{{template "user-suspended"}}
 		{{end}}
 		<header>
 		<h1 dir="{{.Direction}}" id="blog-title"><a href="/{{.Alias}}/" class="h-card p-author u-url" rel="me author">{{.DisplayTitle}}</a></h1>

--- a/templates/password-collection.tmpl
+++ b/templates/password-collection.tmpl
@@ -25,9 +25,6 @@
 
 	</head>
 	<body id="collection" itemscope itemtype="http://schema.org/WebPage">
-		{{if .Suspended}}
-			{{template "user-suspended"}}
-		{{end}}
 		<header>
 		<h1 dir="{{.Direction}}" id="blog-title"><a href="/{{.Alias}}/" class="h-card p-author u-url" rel="me author">{{.DisplayTitle}}</a></h1>
 		</header>


### PR DESCRIPTION
A typo in the `password-protected.tmpl` template would previously cause the page to fail. This fixes that.

It also updates the "silenced" alert text in `edit-meta.tmpl`.

Resolves #221.