### PR TITLE
v0.11.2 hotfix

### DIFF
--- a/app.go
+++ b/app.go
@@ -56,7 +56,7 @@ var (
 	debugging bool
 
 	// Software version can be set from git env using -ldflags
-	softwareVer = "0.11.1"
+	softwareVer = "0.11.2"
 
 	// DEPRECATED VARS
 	isSingleUser bool

--- a/collections.go
+++ b/collections.go
@@ -648,6 +648,16 @@ func processCollectionPermissions(app *App, cr *collectionReq, u *User, w http.R
 				uname = u.Username
 			}
 
+			// TODO: move this to all permission checks?
+			suspended, err := app.db.IsUserSuspended(c.OwnerID)
+			if err != nil {
+				log.Error("process protected collection permissions: %v", err)
+				return nil, err
+			}
+			if suspended {
+				return nil, ErrCollectionNotFound
+			}
+
 			// See if we've authorized this collection
 			authd := isAuthorizedForCollection(app, c.Alias, r)
 

--- a/pad.go
+++ b/pad.go
@@ -92,6 +92,7 @@ func handleViewPad(app *App, w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
+		appData.EditCollection.hostName = app.cfg.App.Host
 	} else {
 		// Editing a floating article
 		appData.Post = getRawPost(app, action)
@@ -161,6 +162,7 @@ func handleViewMeta(app *App, w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
+		appData.EditCollection.hostName = app.cfg.App.Host
 	} else {
 		// Editing a floating article
 		appData.Post = getRawPost(app, action)

--- a/posts.go
+++ b/posts.go
@@ -381,10 +381,12 @@ func handleViewPost(app *App, w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	suspended, err := app.db.IsUserSuspended(ownerID.Int64)
-	if err != nil {
-		log.Error("view post: %v", err)
-		return ErrInternalGeneral
+	var suspended bool
+	if found {
+		suspended, err = app.db.IsUserSuspended(ownerID.Int64)
+		if err != nil {
+			log.Error("view post: %v", err)
+		}
 	}
 
 	// Check if post has been unpublished
@@ -511,7 +513,6 @@ func newPost(app *App, w http.ResponseWriter, r *http.Request) error {
 	suspended, err := app.db.IsUserSuspended(userID)
 	if err != nil {
 		log.Error("new post: %v", err)
-		return ErrInternalGeneral
 	}
 	if suspended {
 		return ErrUserSuspended
@@ -685,7 +686,6 @@ func existingPost(app *App, w http.ResponseWriter, r *http.Request) error {
 	suspended, err := app.db.IsUserSuspended(userID)
 	if err != nil {
 		log.Error("existing post: %v", err)
-		return ErrInternalGeneral
 	}
 	if suspended {
 		return ErrUserSuspended
@@ -888,7 +888,6 @@ func addPost(app *App, w http.ResponseWriter, r *http.Request) error {
 	suspended, err := app.db.IsUserSuspended(ownerID)
 	if err != nil {
 		log.Error("add post: %v", err)
-		return ErrInternalGeneral
 	}
 	if suspended {
 		return ErrUserSuspended
@@ -991,7 +990,6 @@ func pinPost(app *App, w http.ResponseWriter, r *http.Request) error {
 	suspended, err := app.db.IsUserSuspended(userID)
 	if err != nil {
 		log.Error("pin post: %v", err)
-		return ErrInternalGeneral
 	}
 	if suspended {
 		return ErrUserSuspended
@@ -1073,7 +1071,6 @@ func fetchPost(app *App, w http.ResponseWriter, r *http.Request) error {
 	suspended, err := app.db.IsUserSuspended(p.OwnerID.Int64)
 	if err != nil {
 		log.Error("fetch post: %v", err)
-		return ErrInternalGeneral
 	}
 	if suspended {
 		return ErrPostNotFound
@@ -1335,7 +1332,6 @@ func viewCollectionPost(app *App, w http.ResponseWriter, r *http.Request) error 
 	suspended, err := app.db.IsUserSuspended(c.OwnerID)
 	if err != nil {
 		log.Error("view collection post: %v", err)
-		return ErrInternalGeneral
 	}
 
 	// Check collection permissions

--- a/posts.go
+++ b/posts.go
@@ -1039,7 +1039,6 @@ func pinPost(app *App, w http.ResponseWriter, r *http.Request) error {
 
 func fetchPost(app *App, w http.ResponseWriter, r *http.Request) error {
 	var collID int64
-	var ownerID int64
 	var coll *Collection
 	var err error
 	vars := mux.Vars(r)
@@ -1055,14 +1054,13 @@ func fetchPost(app *App, w http.ResponseWriter, r *http.Request) error {
 			return err
 		}
 		collID = coll.ID
-		ownerID = coll.OwnerID
 	}
 
 	p, err := app.db.GetPost(vars["post"], collID)
 	if err != nil {
 		return err
 	}
-	suspended, err := app.db.IsUserSuspended(ownerID)
+	suspended, err := app.db.IsUserSuspended(p.OwnerID.Int64)
 	if err != nil {
 		log.Error("fetch post: %v", err)
 		return ErrInternalGeneral

--- a/posts.go
+++ b/posts.go
@@ -1342,8 +1342,12 @@ func viewCollectionPost(app *App, w http.ResponseWriter, r *http.Request) error 
 	if c.IsPrivate() && (u == nil || u.ID != c.OwnerID) {
 		return ErrPostNotFound
 	}
-	if c.IsProtected() && ((u == nil || u.ID != c.OwnerID) && !isAuthorizedForCollection(app, c.Alias, r)) {
-		return impart.HTTPError{http.StatusFound, c.CanonicalURL() + "/?g=" + slug}
+	if c.IsProtected() && (u == nil || u.ID != c.OwnerID) {
+		if suspended {
+			return ErrPostNotFound
+		} else if !isAuthorizedForCollection(app, c.Alias, r) {
+			return impart.HTTPError{http.StatusFound, c.CanonicalURL() + "/?g=" + slug}
+		}
 	}
 
 	cr.isCollOwner = u != nil && c.OwnerID == u.ID

--- a/templates/edit-meta.tmpl
+++ b/templates/edit-meta.tmpl
@@ -270,7 +270,7 @@
 		<script>
 function updateMeta() {
 	if ({{.Suspended}}) {
-		alert('Your account is currently supsended, editing posts is disabled.');
+		alert("Your account is silenced, so you can't edit posts.");
 		return
 	}
 	document.getElementById('create-error').style.display = 'none';

--- a/templates/password-collection.tmpl
+++ b/templates/password-collection.tmpl
@@ -25,9 +25,6 @@
 
 	</head>
 	<body id="collection" itemscope itemtype="http://schema.org/WebPage">
-		{{if .Suspended}}
-			{{template "user-supsended"}}
-		{{end}}
 		<header>
 		<h1 dir="{{.Direction}}" id="blog-title"><a href="/{{.Alias}}/" class="h-card p-author u-url" rel="me author">{{.DisplayTitle}}</a></h1>
 		</header>


### PR DESCRIPTION
# v0.11.2

## User-Facing Changes / Fixes

* Fix `Announce`ing posts via ActivityPub (#212)
* Fix `id` property in collection posts ActivityStreams data (#214)
* Remove false "programmer error" log (#216)
* Fix password-protected blog rendering (#221)
* Fix silenced password-protected blog quirks
* Fix wrong errors returned when looking up non-existent paths (#215)