### PR TITLE
Pass OAuth requests through OAuth handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/writeas/go-strip-markdown v2.0.1+incompatible
 	github.com/writeas/go-webfinger v0.0.0-20190106002315-85cf805c86d2
 	github.com/writeas/httpsig v1.0.0
-	github.com/writeas/impart v1.1.0
+	github.com/writeas/impart v1.1.1-0.20191230230525-d3c45ced010d
 	github.com/writeas/monday v0.0.0-20181024183321-54a7dd579219
 	github.com/writeas/nerds v1.0.0
 	github.com/writeas/saturday v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/writeas/httpsig v1.0.0 h1:peIAoIA3DmlP8IG8tMNZqI4YD1uEnWBmkcC9OFPjt3A
 github.com/writeas/httpsig v1.0.0/go.mod h1:7ClMGSrSVXJbmiLa17bZ1LrG1oibGZmUMlh3402flPY=
 github.com/writeas/impart v1.1.0 h1:nPnoO211VscNkp/gnzir5UwCDEvdHThL5uELU60NFSE=
 github.com/writeas/impart v1.1.0/go.mod h1:g0MpxdnTOHHrl+Ca/2oMXUHJ0PcRAEWtkCzYCJUXC9Y=
+github.com/writeas/impart v1.1.1-0.20191230230525-d3c45ced010d h1:PK7DOj3JE6MGf647esPrKzXEHFjGWX2hl22uX79ixaE=
+github.com/writeas/impart v1.1.1-0.20191230230525-d3c45ced010d/go.mod h1:g0MpxdnTOHHrl+Ca/2oMXUHJ0PcRAEWtkCzYCJUXC9Y=
 github.com/writeas/monday v0.0.0-20181024183321-54a7dd579219 h1:baEp0631C8sT2r/hqwypIw2snCFZa6h7U6TojoLHu/c=
 github.com/writeas/monday v0.0.0-20181024183321-54a7dd579219/go.mod h1:NyM35ayknT7lzO6O/1JpfgGyv+0W9Z9q7aE0J8bXxfQ=
 github.com/writeas/nerds v1.0.0 h1:ZzRcCN+Sr3MWID7o/x1cr1ZbLvdpej9Y1/Ho+JKlqxo=

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/gorilla/sessions"
 	"github.com/stretchr/testify/assert"
+	"github.com/writeas/impart"
 	"github.com/writeas/nerds/store"
 	"github.com/writeas/writefreely/config"
 	"net/http"
@@ -139,7 +140,7 @@ func TestViewOauthInit(t *testing.T) {
 			Config: app.Config(),
 			DB:     app.DB(),
 			Store:  app.SessionStore(),
-			oauthClient:writeAsOauthClient{
+			oauthClient: writeAsOauthClient{
 				ClientID:         app.Config().WriteAsOauth.ClientID,
 				ClientSecret:     app.Config().WriteAsOauth.ClientSecret,
 				ExchangeLocation: app.Config().WriteAsOauth.TokenLocation,
@@ -152,9 +153,13 @@ func TestViewOauthInit(t *testing.T) {
 		req, err := http.NewRequest("GET", "/oauth/client", nil)
 		assert.NoError(t, err)
 		rr := httptest.NewRecorder()
-		h.viewOauthInit(nil, rr, req)
-		assert.Equal(t, http.StatusTemporaryRedirect, rr.Code)
-		locURI, err := url.Parse(rr.Header().Get("Location"))
+		err = h.viewOauthInit(nil, rr, req)
+		assert.NotNil(t, err)
+		httpErr, ok := err.(impart.HTTPError)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusTemporaryRedirect, httpErr.Status)
+		assert.NotEmpty(t, httpErr.Message)
+		locURI, err := url.Parse(httpErr.Message)
 		assert.NoError(t, err)
 		assert.Equal(t, "/oauth/login", locURI.Path)
 		assert.Equal(t, "development", locURI.Query().Get("client_id"))
@@ -177,7 +182,7 @@ func TestViewOauthInit(t *testing.T) {
 			Config: app.Config(),
 			DB:     app.DB(),
 			Store:  app.SessionStore(),
-			oauthClient:writeAsOauthClient{
+			oauthClient: writeAsOauthClient{
 				ClientID:         app.Config().WriteAsOauth.ClientID,
 				ClientSecret:     app.Config().WriteAsOauth.ClientSecret,
 				ExchangeLocation: app.Config().WriteAsOauth.TokenLocation,
@@ -190,10 +195,12 @@ func TestViewOauthInit(t *testing.T) {
 		req, err := http.NewRequest("GET", "/oauth/client", nil)
 		assert.NoError(t, err)
 		rr := httptest.NewRecorder()
-		h.viewOauthInit(nil, rr, req)
-		assert.Equal(t, http.StatusInternalServerError, rr.Code)
-		expected := `{"error":"could not prepare oauth redirect url"}` + "\n"
-		assert.Equal(t, expected, rr.Body.String())
+		err = h.viewOauthInit(nil, rr, req)
+		httpErr, ok := err.(impart.HTTPError)
+		assert.True(t, ok)
+		assert.NotEmpty(t, httpErr.Message)
+		assert.Equal(t, http.StatusInternalServerError, httpErr.Status)
+		assert.Equal(t, "could not prepare oauth redirect url", httpErr.Message)
 	})
 }
 

--- a/routes.go
+++ b/routes.go
@@ -87,8 +87,8 @@ func InitRoutes(apper Apper, r *mux.Router) *mux.Router {
 		Store:      apper.App().SessionStore(),
 	}
 
-	write.HandleFunc("/oauth/write.as", oauthHandler.viewOauthInit).Methods("GET")
-	write.HandleFunc("/oauth/callback", oauthHandler.viewOauthCallback).Methods("GET")
+	write.HandleFunc("/oauth/write.as", handler.OAuth(oauthHandler.viewOauthInit)).Methods("GET")
+	write.HandleFunc("/oauth/callback", handler.OAuth(oauthHandler.viewOauthCallback)).Methods("GET")
 
 	// Handle logged in user sections
 	me := write.PathPrefix("/me").Subrouter()


### PR DESCRIPTION
This gives us consistent logging on OAuth endpoints and passes around errors with `impart.HTTPError`, as we do elsewhere -- while keeping the current JSON schema for OAuth requests (`{"error": "..."}`).

@ngerakines curious about your thoughts on this -- whether it works or if it might cause issues down the road, e.g. with error handling for various request types.

Part of [T705](https://writefreely.org/tasks/705).