### PR TITLE
Add dates to blog posts

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -63,6 +63,7 @@ type (
 		TotalPosts int           `json:"total_posts"`
 		Owner      *User         `json:"owner,omitempty"`
 		Posts      *[]PublicPost `json:"posts,omitempty"`
+		Format     *CollectionFormat
 	}
 	DisplayCollection struct {
 		*CollectionObj
@@ -70,7 +71,6 @@ type (
 		IsTopLevel  bool
 		CurrentPage int
 		TotalPages  int
-		Format      *CollectionFormat
 		Suspended   bool
 	}
 	SubmittedCollection struct {
@@ -556,6 +556,13 @@ type CollectionPage struct {
 	CanInvite      bool
 }
 
+func NewCollectionObj(c *Collection) *CollectionObj {
+	return &CollectionObj{
+		Collection: *c,
+		Format:     c.NewFormat(),
+	}
+}
+
 func (c *CollectionObj) ScriptDisplay() template.JS {
 	return template.JS(c.Script)
 }
@@ -705,11 +712,10 @@ func checkUserForCollection(app *App, cr *collectionReq, r *http.Request, isPost
 
 func newDisplayCollection(c *Collection, cr *collectionReq, page int) *DisplayCollection {
 	coll := &DisplayCollection{
-		CollectionObj: &CollectionObj{Collection: *c},
+		CollectionObj: NewCollectionObj(c),
 		CurrentPage:   page,
 		Prefix:        cr.prefix,
 		IsTopLevel:    isSingleUser,
-		Format:        c.NewFormat(),
 	}
 	c.db.GetPostsCount(coll.CollectionObj, cr.isCollOwner)
 	return coll

--- a/less/post-temp.less
+++ b/less/post-temp.less
@@ -17,6 +17,16 @@ body {
 				font-size: 1.6em;
 			}
 		}
+		article {
+			h2#title.dated {
+				margin-bottom: 0.5em;
+			}
+			time.dt-published {
+				display: block;
+				color: #666;
+				margin-bottom: 1em;
+			}
+		}
 	}
 }
 

--- a/posts.go
+++ b/posts.go
@@ -1354,7 +1354,7 @@ func viewCollectionPost(app *App, w http.ResponseWriter, r *http.Request) error 
 
 	// Fetch extra data about the Collection
 	// TODO: refactor out this logic, shared in collection.go:fetchCollection()
-	coll := &CollectionObj{Collection: *c}
+	coll := NewCollectionObj(c)
 	owner, err := app.db.GetUserByID(coll.OwnerID)
 	if err != nil {
 		// Log the error and just continue

--- a/templates/chorus-collection-post.tmpl
+++ b/templates/chorus-collection-post.tmpl
@@ -38,16 +38,6 @@ body footer {
 body#post header {
 	padding: 1em 1rem;
 }
-article time.dt-published {
-	display: block;
-	color: #666;
-}
-body#post article h2#title{
-	margin-bottom: 0.5em;
-}
-article time.dt-published {
-	margin-bottom: 1em;
-}
 	</style>
 
 		{{if .Collection.RenderMathJax}}
@@ -68,7 +58,7 @@ article time.dt-published {
 		{{if .Suspended}}
 			{{template "user-suspended"}}
 		{{end}}
-		<article id="post-body" class="{{.Font}} h-entry">{{if .IsScheduled}}<p class="badge">Scheduled</p>{{end}}{{if .Title.String}}<h2 id="title" class="p-name">{{.FormattedDisplayTitle}}</h2>{{end}}{{/* TODO: check format: if .Collection.Format.ShowDates*/}}<time class="dt-published" datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</time><div class="e-content">{{.HTMLContent}}</div></article>
+		<article id="post-body" class="{{.Font}} h-entry">{{if .IsScheduled}}<p class="badge">Scheduled</p>{{end}}{{if .Title.String}}<h2 id="title" class="p-name{{if $.Collection.Format.ShowDates}} dated{{end}}">{{.FormattedDisplayTitle}}</h2>{{end}}{{if $.Collection.Format.ShowDates}}<time class="dt-published" datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</time>{{end}}<div class="e-content">{{.HTMLContent}}</div></article>
 
 		{{ if .Collection.ShowFooterBranding }}
 		<footer dir="ltr">

--- a/templates/collection-post.tmpl
+++ b/templates/collection-post.tmpl
@@ -62,7 +62,7 @@
 		{{if .Suspended}}
 			{{template "user-suspended"}}
 		{{end}}
-		<article id="post-body" class="{{.Font}} h-entry {{if not .IsFound}}error-page{{end}}">{{if .IsScheduled}}<p class="badge">Scheduled</p>{{end}}{{if .Title.String}}<h2 id="title" class="p-name">{{.FormattedDisplayTitle}}</h2>{{end}}<div class="e-content">{{.HTMLContent}}</div></article>
+		<article id="post-body" class="{{.Font}} h-entry {{if not .IsFound}}error-page{{end}}">{{if .IsScheduled}}<p class="badge">Scheduled</p>{{end}}{{if .Title.String}}<h2 id="title" class="p-name{{if $.Collection.Format.ShowDates}} dated{{end}}">{{.FormattedDisplayTitle}}</h2>{{end}}{{if $.Collection.Format.ShowDates}}<time class="dt-published" datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</time>{{end}}<div class="e-content">{{.HTMLContent}}</div></article>
 
 		{{ if .Collection.ShowFooterBranding }}
 		<footer dir="ltr"><hr><nav><p style="font-size: 0.9em">{{localhtml "published with write.as" .Language.String}}</p></nav></footer>


### PR DESCRIPTION
This shows the publish date for collection posts when a collection is set to the "Blog" display format, making individual post pages consistent with the index page.

This resolves [T669](https://writefreely.org/tasks/669).