### PR TITLE
OAuth alias field not set correctly

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -224,6 +224,11 @@ func (h oauthHandler) viewOauthCallback(app *App, w http.ResponseWriter, r *http
 		return nil
 	}
 
+	displayName := tokenInfo.DisplayName
+	if len(displayName) == 0 {
+		displayName = tokenInfo.Username
+	}
+
 	tp := &oauthSignupPageParams{
 		AccessToken:     tokenResponse.AccessToken,
 		TokenUsername:   tokenInfo.Username,


### PR DESCRIPTION
This PR resolves a bug where the alias field used during oauth registration was not correctly set for the write.as oauth provider.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
