### PR TITLE
Switch to a maintained fork of XGO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,12 @@ build-darwin: deps
 	fi
 	xgo --targets=darwin/amd64, -dest build/ $(LDFLAGS) -tags='sqlite' -out writefreely ./cmd/writefreely
 
+build-arm6: deps
+	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
+		$(GOGET) -u src.techknowlogick.com/xgo; \
+	fi
+	xgo --targets=linux/arm-6, -dest build/ $(LDFLAGS) -tags='sqlite' -out writefreely ./cmd/writefreely
+
 build-arm7: deps
 	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		$(GOGET) -u src.techknowlogick.com/xgo; \
@@ -84,6 +90,10 @@ release : clean ui assets
 	$(MAKE) build-linux
 	mv build/$(BINARY_NAME)-linux-amd64 $(BUILDPATH)/$(BINARY_NAME)
 	tar -cvzf $(BINARY_NAME)_$(GITREV)_linux_amd64.tar.gz -C build $(BINARY_NAME)
+	rm $(BUILDPATH)/$(BINARY_NAME)
+	$(MAKE) build-arm6
+	mv build/$(BINARY_NAME)-linux-arm-6 $(BUILDPATH)/$(BINARY_NAME)
+	tar -cvzf $(BINARY_NAME)_$(GITREV)_linux_arm6.tar.gz -C build $(BINARY_NAME)
 	rm $(BUILDPATH)/$(BINARY_NAME)
 	$(MAKE) build-arm7
 	mv build/$(BINARY_NAME)-linux-arm-7 $(BUILDPATH)/$(BINARY_NAME)

--- a/Makefile
+++ b/Makefile
@@ -25,31 +25,31 @@ build-no-sqlite: assets-no-sqlite deps-no-sqlite
 
 build-linux: deps
 	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		$(GOGET) -u github.com/karalabe/xgo; \
+		$(GOGET) -u src.techknowlogick.com/xgo; \
 	fi
 	xgo --targets=linux/amd64, -dest build/ $(LDFLAGS) -tags='sqlite' -out writefreely ./cmd/writefreely
 
 build-windows: deps
 	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		$(GOGET) -u github.com/karalabe/xgo; \
+		$(GOGET) -u src.techknowlogick.com/xgo; \
 	fi
 	xgo --targets=windows/amd64, -dest build/ $(LDFLAGS) -tags='sqlite' -out writefreely ./cmd/writefreely
 
 build-darwin: deps
 	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		$(GOGET) -u github.com/karalabe/xgo; \
+		$(GOGET) -u src.techknowlogick.com/xgo; \
 	fi
 	xgo --targets=darwin/amd64, -dest build/ $(LDFLAGS) -tags='sqlite' -out writefreely ./cmd/writefreely
 
 build-arm7: deps
 	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		$(GOGET) -u github.com/karalabe/xgo; \
+		$(GOGET) -u src.techknowlogick.com/xgo; \
 	fi
 	xgo --targets=linux/arm-7, -dest build/ $(LDFLAGS) -tags='sqlite' -out writefreely ./cmd/writefreely
 
 build-arm64: deps
 	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		$(GOGET) -u github.com/karalabe/xgo; \
+		$(GOGET) -u src.techknowlogick.com/xgo; \
 	fi
 	xgo --targets=linux/arm64, -dest build/ $(LDFLAGS) -tags='sqlite' -out writefreely ./cmd/writefreely
 
@@ -145,7 +145,7 @@ $(TMPBIN)/go-bindata: deps $(TMPBIN)
 	$(GOBUILD) -o $(TMPBIN)/go-bindata github.com/jteeuwen/go-bindata/go-bindata
 
 $(TMPBIN)/xgo: deps $(TMPBIN)
-	$(GOBUILD) -o $(TMPBIN)/xgo github.com/karalabe/xgo
+	$(GOBUILD) -o $(TMPBIN)/xgo src.techknowlogick.com/xgo
 
 ci-assets : $(TMPBIN)/go-bindata
 	$(TMPBIN)/go-bindata -pkg writefreely -ignore=\\.gitignore -tags="!wflib" schema.sql sqlite.sql

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c // indirect
 	gopkg.in/ini.v1 v1.41.0
 	gopkg.in/yaml.v2 v2.2.2 // indirect
+	src.techknowlogick.com/xgo v0.0.0-20200129005940-d0fae26e014b // indirect
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -176,3 +176,5 @@ gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 h1:POO/ycCATvegFmVuPpQzZFJ+p
 gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+src.techknowlogick.com/xgo v0.0.0-20200129005940-d0fae26e014b h1:rPAdjgXks4ToezTjygsnKZroxKVnA1L35DSpsJXPtfc=
+src.techknowlogick.com/xgo v0.0.0-20200129005940-d0fae26e014b/go.mod h1:31CE1YKtDOrKTk9PSnjTpe6YbO6W/0LTYZ1VskL09oU=


### PR DESCRIPTION
👋 Hey, I'm one of the project leads for [Gitea](https://gitea.io/en-us/), and we also use XGO to cross compile our binaries, however we have forked xgo to ensure that versions are kept up to date and have added other enhancements.

I've also added arm-6 as a compile target, this is due to its wider support on arm based devices (arm6 works on arm7 devices, but not the reverse).

Note: Due to switching from Ubuntu 14.04 to 18.04 as a base image in the fork this prevents binaries from working on Linux Kernel versions below 3.1. However due to Ubuntu 14.04 being past EOL, and also that Linux Kernel version being of a certain age Gitea proceeded with that being acceptable (it may not be acceptable for you).

I understand that this is an unsolicited PR, and it changes an upstream dependency, as such please feel free to close it if it doesn't align with your project. 

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
