### PR TITLE
Require authenticated user for editor access

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -169,9 +169,9 @@ func InitRoutes(apper Apper, r *mux.Router) *mux.Router {
 	draftEditPrefix := ""
 	if apper.App().cfg.App.SingleUser {
 		draftEditPrefix = "/d"
-		write.HandleFunc("/me/new", handler.Web(handleViewPad, UserLevelOptional)).Methods("GET")
+		write.HandleFunc("/me/new", handler.Web(handleViewPad, UserLevelUser)).Methods("GET")
 	} else {
-		write.HandleFunc("/new", handler.Web(handleViewPad, UserLevelOptional)).Methods("GET")
+		write.HandleFunc("/new", handler.Web(handleViewPad, UserLevelUser)).Methods("GET")
 	}
 
 	// All the existing stuff


### PR DESCRIPTION
Previously, anyone could access the editor at `/new` (multi-user) or `/me/new` (single-user) even if they weren't logged in. They couldn't do much in that case (publishing would fail), but it could potentially cause some confusion.

Now, users will be sent to the login page, and then redirected back to the editor once successfully logged in.