### PR TITLE
update upgrade script for recent changes

### DIFF
--- a/scripts/upgrade-server.sh
+++ b/scripts/upgrade-server.sh
@@ -11,7 +11,7 @@
 ##	have not installed the binary `writefreely` in another location.     ##
 ###############################################################################
 #
-#	Copyright © 2019 A Bunch Tell LLC.
+#	Copyright © 2019-2020 A Bunch Tell LLC.
 #
 #	This file is part of WriteFreely.
 #

--- a/scripts/upgrade-server.sh
+++ b/scripts/upgrade-server.sh
@@ -99,7 +99,7 @@ cp -r $tempdir/writefreely/{pages,static,templates,writefreely} .
 ./writefreely -migrate
 
 # restart service
-echo "Restarting writefreely systemd service..."
+echo "Starting writefreely systemd service..."
 if `systemctl start writefreely`; then
 	echo "Success, version has been upgraded to $latest."
 else


### PR DESCRIPTION
changes accounted for
- the tar directory structure had changed to use a subdirectory
- there are now multiple linux targets released

bugs
- the service must be stopped before replacing the binary
- migrations were not being run during an upgrade

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
