### PR TITLE
A minor Drafts page fix + improvement

### DIFF
--- a/posts.go
+++ b/posts.go
@@ -229,6 +229,10 @@ func (p Post) Summary() string {
 	return shortPostDescription(p.Content)
 }
 
+func (p Post) SummaryHTML() template.HTML {
+	return template.HTML(p.Summary())
+}
+
 // Excerpt shows any text that comes before a (more) tag.
 // TODO: use HTMLExcerpt in templates instead of this method
 func (p *Post) Excerpt() template.HTML {

--- a/templates/user/articles.tmpl
+++ b/templates/user/articles.tmpl
@@ -12,7 +12,10 @@
 
 <h2 id="posts-header">drafts</h2>
 
-{{ if .AnonymousPosts }}<div class="atoms posts">
+{{ if .AnonymousPosts }}
+	<p>These are your draft posts. You can share them individually (without a blog) or move them to your blog when you're ready.</p>
+
+	<div class="atoms posts">
 	{{ range $el := .AnonymousPosts }}<div id="post-{{.ID}}" class="post">
 		<h3><a href="/{{if $.SingleUser}}d/{{end}}{{.ID}}" itemprop="url">{{.DisplayTitle}}</a></h3>
 		<h4>
@@ -36,8 +39,9 @@
 		</h4>
 		{{if .Summary}}<p>{{.SummaryHTML}}</p>{{end}}
 	</div>{{end}}
-</div>{{ else }}<div id="no-posts-published"><p>You haven't saved any drafts yet.</p>
-	<p>They'll show up here once you do. {{if not .SingleUser}}Find your blog posts from the <a href="/me/c/">Blogs</a> page.{{end}}</p>
+</div>{{ else }}<div id="no-posts-published">
+	<p>Your anonymous and draft posts will show up here once you've published some. You'll be able to share them individually (without a blog) or move them to a blog when you're ready.</p>
+	{{if not .SingleUser}}<p>Alternatively, see your blogs and their posts on your <a href="/me/c/">Blogs</a> page.</p>{{end}}
 	<p class="text-cta"><a href="{{if .SingleUser}}/me/new{{else}}/{{end}}">Start writing</a></p></div>{{ end }}
 
 <div id="moving"></div>

--- a/templates/user/articles.tmpl
+++ b/templates/user/articles.tmpl
@@ -34,7 +34,7 @@
 			{{end}}
 			{{ end }}
 		</h4>
-		{{if .Summary}}<p>{{.Summary}}</p>{{end}}
+		{{if .Summary}}<p>{{.SummaryHTML}}</p>{{end}}
 	</div>{{end}}
 </div>{{ else }}<div id="no-posts-published"><p>You haven't saved any drafts yet.</p>
 	<p>They'll show up here once you do. {{if not .SingleUser}}Find your blog posts from the <a href="/me/c/">Blogs</a> page.{{end}}</p>


### PR DESCRIPTION
* Previously, we'd show the raw HTML entities in the summaries of Draft posts, instead of rendering them. This fixes that.
* Explain what "Drafts" are at the top of the page