### PR TITLE
Improve resource use for federation

### DIFF
--- a/activitypub.go
+++ b/activitypub.go
@@ -62,8 +62,8 @@ func (ru *RemoteUser) AsPerson() *activitystreams.Person {
 	}
 }
 
-func activityPubClient() http.Client {
-	return http.Client{
+func activityPubClient() *http.Client {
+	return &http.Client{
 		Timeout: 15 * time.Second,
 	}
 }

--- a/activitypub.go
+++ b/activitypub.go
@@ -388,6 +388,11 @@ func handleFetchCollectionInbox(app *App, w http.ResponseWriter, r *http.Request
 	}
 
 	go func() {
+		if to == nil {
+			log.Error("No to! %v", err)
+			return
+		}
+
 		time.Sleep(2 * time.Second)
 		am, err := a.Serialize()
 		if err != nil {
@@ -396,10 +401,6 @@ func handleFetchCollectionInbox(app *App, w http.ResponseWriter, r *http.Request
 		}
 		am["@context"] = []string{activitystreams.Namespace}
 
-		if to == nil {
-			log.Error("No to! %v", err)
-			return
-		}
 		err = makeActivityPost(app.cfg.App.Host, p, fullActor.Inbox, am)
 		if err != nil {
 			log.Error("Unable to make activity POST: %v", err)

--- a/activitypub.go
+++ b/activitypub.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 A Bunch Tell LLC.
+ * Copyright © 2018-2020 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -59,6 +59,12 @@ func (ru *RemoteUser) AsPerson() *activitystreams.Person {
 		Endpoints: activitystreams.Endpoints{
 			SharedInbox: ru.SharedInbox,
 		},
+	}
+}
+
+func activityPubClient() http.Client {
+	return http.Client{
+		Timeout: 15 * time.Second,
 	}
 }
 
@@ -502,7 +508,7 @@ func makeActivityPost(hostName string, p *activitystreams.Person, url string, m 
 		}
 	}
 
-	resp, err := http.DefaultClient.Do(r)
+	resp, err := activityPubClient().Do(r)
 	if err != nil {
 		return err
 	}
@@ -538,7 +544,7 @@ func resolveIRI(hostName, url string) ([]byte, error) {
 		}
 	}
 
-	resp, err := http.DefaultClient.Do(r)
+	resp, err := activityPubClient().Do(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a work in progress that'll include various improvements to federation with ActivityPub. Included:

* Add timeout on ActivityPub requests. Previously, if a fediverse instance was slow or offline, requests could hang indefinitely. This should fix that.