### PR TITLE
Restrict /invite/{code} route to valid chars

### DIFF
--- a/database-no-sqlite.go
+++ b/database-no-sqlite.go
@@ -1,7 +1,7 @@
 // +build !sqlite,!wflib
 
 /*
- * Copyright © 2019 A Bunch Tell LLC.
+ * Copyright © 2019-2020 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -24,6 +24,18 @@ func (db *datastore) isDuplicateKeyErr(err error) bool {
 		}
 	} else {
 		log.Error("isDuplicateKeyErr: failed check for unrecognized driver '%s'", db.driverName)
+	}
+
+	return false
+}
+
+func (db *datastore) isIgnorableError(err error) bool {
+	if db.driverName == driverMySQL {
+		if mysqlErr, ok := err.(*mysql.MySQLError); ok {
+			return mysqlErr.Number == mySQLErrCollationMix
+		}
+	} else {
+		log.Error("isIgnorableError: failed check for unrecognized driver '%s'", db.driverName)
 	}
 
 	return false

--- a/database-sqlite.go
+++ b/database-sqlite.go
@@ -48,3 +48,15 @@ func (db *datastore) isDuplicateKeyErr(err error) bool {
 
 	return false
 }
+
+func (db *datastore) isIgnorableError(err error) bool {
+	if db.driverName == driverMySQL {
+		if mysqlErr, ok := err.(*mysql.MySQLError); ok {
+			return mysqlErr.Number == mySQLErrCollationMix
+		}
+	} else {
+		log.Error("isIgnorableError: failed check for unrecognized driver '%s'", db.driverName)
+	}
+
+	return false
+}

--- a/database.go
+++ b/database.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 A Bunch Tell LLC.
+ * Copyright © 2018-2020 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -37,6 +37,7 @@ import (
 
 const (
 	mySQLErrDuplicateKey = 1062
+	mySQLErrCollationMix = 1267
 
 	driverMySQL  = "mysql"
 	driverSQLite = "sqlite3"
@@ -2281,7 +2282,7 @@ func (db *datastore) GetUserInvite(id string) (*Invite, error) {
 	var i Invite
 	err := db.QueryRow("SELECT id, max_uses, created, expires, inactive FROM userinvites WHERE id = ?", id).Scan(&i.ID, &i.MaxUses, &i.Created, &i.Expires, &i.Inactive)
 	switch {
-	case err == sql.ErrNoRows:
+	case err == sql.ErrNoRows, db.isIgnorableError(err):
 		return nil, impart.HTTPError{http.StatusNotFound, "Invite doesn't exist."}
 	case err != nil:
 		log.Error("Failed selecting invite: %v", err)

--- a/routes.go
+++ b/routes.go
@@ -161,7 +161,7 @@ func InitRoutes(apper Apper, r *mux.Router) *mux.Router {
 	// Handle special pages first
 	write.HandleFunc("/login", handler.Web(viewLogin, UserLevelNoneRequired))
 	write.HandleFunc("/signup", handler.Web(handleViewLanding, UserLevelNoneRequired))
-	write.HandleFunc("/invite/{code}", handler.Web(handleViewInvite, UserLevelOptional)).Methods("GET")
+	write.HandleFunc("/invite/{code:[a-zA-Z0-9]+}", handler.Web(handleViewInvite, UserLevelOptional)).Methods("GET")
 	// TODO: show a reader-specific 404 page if the function is disabled
 	write.HandleFunc("/read", handler.Web(viewLocalTimeline, UserLevelReader))
 	RouteRead(handler, UserLevelReader, write.PathPrefix("/read").Subrouter())


### PR DESCRIPTION
Previously, loading something like `/invite/fFdblk😄` would return a 500, due to a mix of collations in MySQL while SELECTing for an invite with an ID of 'fFdblk😄'. This restricts the route to `[a-zA-Z0-9]` chars, to prevent this.

Fixes #250