### PR TITLE
Require authenticated user on draft edit routes

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -175,8 +175,8 @@ func InitRoutes(apper Apper, r *mux.Router) *mux.Router {
 	}
 
 	// All the existing stuff
-	write.HandleFunc(draftEditPrefix+"/{action}/edit", handler.Web(handleViewPad, UserLevelOptional)).Methods("GET")
-	write.HandleFunc(draftEditPrefix+"/{action}/meta", handler.Web(handleViewMeta, UserLevelOptional)).Methods("GET")
+	write.HandleFunc(draftEditPrefix+"/{action}/edit", handler.Web(handleViewPad, UserLevelUser)).Methods("GET")
+	write.HandleFunc(draftEditPrefix+"/{action}/meta", handler.Web(handleViewMeta, UserLevelUser)).Methods("GET")
 	// Collections
 	if apper.App().cfg.App.SingleUser {
 		RouteCollections(handler, write.PathPrefix("/").Subrouter())


### PR DESCRIPTION
This updates permissions on draft editing routes (both `/edit` and `/meta`) to require an authenticated user, just like we do on collection post editing routes.

Closes #255