### PR TITLE
Consistent backend page design

### DIFF
--- a/less/core.less
+++ b/less/core.less
@@ -794,9 +794,6 @@ input {
 	&.snug {
 		max-width: 40em;
 	}
-	&.regular {
-		font-size: 1em;
-	}
 	.app {
 		+ .app {
 			margin-top: 1.5em;

--- a/templates/read.tmpl
+++ b/templates/read.tmpl
@@ -75,11 +75,14 @@
 		body#collection header nav.tabs a:first-child {
 			margin-left: 1em;
 		}
+		body#collection article {
+			max-width: 40em !important;
+		}
 		</style>
 {{end}}
 {{define "body-attrs"}}id="collection"{{end}}
 {{define "content"}}
-	<div class="content-container snug" style="max-width: 40rem;">
+	<div class="content-container snug">
 		<h1>{{.ContentTitle}}</h1>
 		<p{{if .SelTopic}} style="text-align:center"{{end}}>{{if .SelTopic}}#{{.SelTopic}} posts{{else}}{{.Content}}{{end}}</p>
 	</div>

--- a/templates/user/articles.tmpl
+++ b/templates/user/articles.tmpl
@@ -10,7 +10,7 @@
 	{{template "user-silenced"}}
 {{end}}
 
-<h2 id="posts-header">drafts</h2>
+<h1 id="posts-header">Drafts</h1>
 
 {{ if .AnonymousPosts }}
 	<p>These are your draft posts. You can share them individually (without a blog) or move them to your blog when you're ready.</p>

--- a/templates/user/collections.tmpl
+++ b/templates/user/collections.tmpl
@@ -10,7 +10,7 @@
 {{if .Silenced}}
 	{{template "user-silenced"}}
 {{end}}
-<h2>blogs</h2>
+<h1>Blogs</h1>
 <ul class="atoms collections">
 	{{range $i, $el := .Collections}}<li class="collection"><h3>
 		<a class="title" href="/{{.Alias}}/">{{if .Title}}{{.Title}}{{else}}{{.Alias}}{{end}}</a>

--- a/templates/user/export.tmpl
+++ b/templates/user/export.tmpl
@@ -2,7 +2,7 @@
 {{template "header" .}}
 
 <div class="snug content-container">
-	<h2 id="posts-header">Export</h2>
+	<h1 id="posts-header">Export</h1>
 	<p>Your data on {{.SiteName}} is always free. Download and back-up your work any time.</p>
 
 	<table class="classy export">

--- a/templates/user/settings.tmpl
+++ b/templates/user/settings.tmpl
@@ -6,11 +6,11 @@
 h3 { font-weight: normal; }
 .section > *:not(input) { font-size: 0.86em; }
 </style>
-<div class="content-container snug regular">
+<div class="content-container snug">
 	{{if .Silenced}}
 		{{template "user-silenced"}}
 	{{end}}
-	<h2>{{if .IsLogOut}}Before you go...{{else}}Account Settings {{if .IsAdmin}}<a href="/admin">admin settings</a>{{end}}{{end}}</h2>
+	<h1>{{if .IsLogOut}}Before you go...{{else}}Account Settings {{if .IsAdmin}}<a href="/admin">admin settings</a>{{end}}{{end}}</h1>
 	{{if .Flashes}}<ul class="errors">
 		{{range .Flashes}}<li class="urgent">{{.}}</li>{{end}}
 	</ul>{{end}}
@@ -20,7 +20,7 @@ h3 { font-weight: normal; }
 		<p class="introduction">Please add an <strong>email address</strong> and/or <strong>passphrase</strong> so you can log in again later.</p>
 	</div>
 	{{ else }}
-	<div class="option">
+	<div>
 		<p>Change your account settings here.</p>
 	</div>
 


### PR DESCRIPTION
This fixes various pages that used `<h2>`s instead of `<h1>`s:

* Drafts
* Blogs
* Account Settings
* Export

It also fixes the width of content in the Reader page so it's consistent with all other pages.