### PR TITLE
Typography Improvements, Vol. I

### DIFF
--- a/less/core.less
+++ b/less/core.less
@@ -644,7 +644,7 @@ body#collection article, body#subpage article {
 	padding-bottom: 0;
 	.book {
 		h2 {
-			font-size: 1.5;
+			font-size: 1.4em;
 		}
 		a.hidden.action {
 			 color: #666;

--- a/less/core.less
+++ b/less/core.less
@@ -524,12 +524,12 @@ pre, body#post article, #post .alert, #subpage .alert, body#collection article, 
 	margin-bottom: 1em;
 	p {
 		text-align: left;
-		line-height: 1.4;
+		line-height: 1.5;
 	}
 }
 textarea, pre, body#post article, body#collection article p {
 	&.norm, &.sans, &.wrap {
-		line-height: 1.4em;
+		line-height: 1.5;
 		white-space: pre-wrap;       /* CSS 3 */
 		white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
 		white-space: -pre-wrap;      /* Opera 4-6 */
@@ -644,7 +644,7 @@ body#collection article, body#subpage article {
 	padding-bottom: 0;
 	.book {
 		h2 {
-			font-size: 1.4em;
+			font-size: 1.5;
 		}
 		a.hidden.action {
 			 color: #666;
@@ -813,7 +813,7 @@ input {
 		font-weight: normal;
 	}
 	p {
-		line-height: 1.4;
+		line-height: 1.5;
 	}
 	li {
 		margin: 0.3em 0;
@@ -1007,7 +1007,7 @@ footer.contain-me {
 }
 
 li {
-	line-height: 1.4;
+	line-height: 1.5;
 
 	.item-desc, .prog-lang {
 		font-size: 0.6em;

--- a/less/new-core.less
+++ b/less/new-core.less
@@ -113,7 +113,7 @@ textarea {
 	ul {
 		margin: 0;
 		padding: 0 0 0 1em;
-		line-height: 1.4;
+		line-height: 1.5;
 
 		&.collections, &.posts, &.integrations {
 			list-style: none;
@@ -206,7 +206,7 @@ code, textarea#embed {
 		font-weight: normal;
 	}
 	p {
-		line-height: 1.4;
+		line-height: 1.5;
 	}
 	li {
 		margin: 0.3em 0;

--- a/less/post-temp.less
+++ b/less/post-temp.less
@@ -58,7 +58,7 @@ body#post article, pre, .hljs {
 	}
 }
 .article-p() {
-	line-height: 1.4em;
+	line-height: 1.5;
 	white-space: pre-wrap;       /* CSS 3 */
 	white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
 	white-space: -pre-wrap;      /* Opera 4-6 */


### PR DESCRIPTION
This PR aims to introduce small, incremental improvements to the typography on WriteFreely. As these changes will affect all aspects of WF, including user blogs, the goal is to not introduce any major, jarring changes that will negatively impact users.

All typographical input is welcome here -- please feel free to comment with any improvements you would like to see so we can discuss and possibly include them here.

## Changes

* Change line height from 1.4 to 1.5