### PR TITLE
Admin dashboard redesign

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -443,8 +443,9 @@ func handleViewAdminPage(app *App, u *User, w http.ResponseWriter, r *http.Reque
 		Banner  *instanceContent
 		Content *instanceContent
 	}{
-		Config:  app.cfg.App,
-		Message: r.FormValue("m"),
+		AdminPage: NewAdminPage(app),
+		Config:    app.cfg.App,
+		Message:   r.FormValue("m"),
 	}
 
 	var err error

--- a/admin.go
+++ b/admin.go
@@ -584,6 +584,7 @@ func handleViewAdminUpdates(app *App, u *User, w http.ResponseWriter, r *http.Re
 	p := struct {
 		*UserPage
 		LastChecked           string
+		LastChecked8601       string
 		LatestVersion         string
 		LatestReleaseNotesURL string
 		UpdateAvailable       bool
@@ -592,6 +593,7 @@ func handleViewAdminUpdates(app *App, u *User, w http.ResponseWriter, r *http.Re
 	}
 	if app.cfg.App.UpdateChecks {
 		p.LastChecked = app.updates.lastCheck.Format("January 2, 2006, 3:04 PM")
+		p.LastChecked8601 = app.updates.lastCheck.Format("2006-01-02T15:04:05Z")
 		p.LatestVersion = app.updates.LatestVersion()
 		p.LatestReleaseNotesURL = app.updates.ReleaseNotesURL()
 		p.UpdateAvailable = app.updates.AreAvailable()

--- a/admin.go
+++ b/admin.go
@@ -612,6 +612,7 @@ func handleViewAdminUpdates(app *App, u *User, w http.ResponseWriter, r *http.Re
 		LatestVersion         string
 		LatestReleaseURL      string
 		LatestReleaseNotesURL string
+		CheckFailed           bool
 	}{
 		UserPage:  NewUserPage(app, r, u, "Updates", nil),
 		AdminPage: NewAdminPage(app),
@@ -624,6 +625,7 @@ func handleViewAdminUpdates(app *App, u *User, w http.ResponseWriter, r *http.Re
 		p.LatestReleaseURL = app.updates.ReleaseURL()
 		p.LatestReleaseNotesURL = app.updates.ReleaseNotesURL()
 		p.UpdateAvailable = app.updates.AreAvailable()
+		p.CheckFailed = app.updates.checkError != nil
 	}
 
 	showUserPage(w, "app-updates", p)

--- a/admin.go
+++ b/admin.go
@@ -583,6 +583,7 @@ func handleViewAdminUpdates(app *App, u *User, w http.ResponseWriter, r *http.Re
 
 	p := struct {
 		*UserPage
+		CurReleaseNotesURL    string
 		LastChecked           string
 		LastChecked8601       string
 		LatestVersion         string
@@ -592,6 +593,7 @@ func handleViewAdminUpdates(app *App, u *User, w http.ResponseWriter, r *http.Re
 	}{
 		UserPage: NewUserPage(app, r, u, "Updates", nil),
 	}
+	p.CurReleaseNotesURL = wfReleaseNotesURL(p.Version)
 	if app.cfg.App.UpdateChecks {
 		p.LastChecked = app.updates.lastCheck.Format("January 2, 2006, 3:04 PM")
 		p.LastChecked8601 = app.updates.lastCheck.Format("2006-01-02T15:04:05Z")

--- a/admin.go
+++ b/admin.go
@@ -90,6 +90,16 @@ type instanceContent struct {
 	Updated time.Time
 }
 
+type AdminPage struct {
+	UpdateAvailable bool
+}
+
+func NewAdminPage(app *App) *AdminPage {
+	return &AdminPage{
+		UpdateAvailable: app.updates.AreAvailableNoCheck(),
+	}
+}
+
 func (c instanceContent) UpdatedFriendly() string {
 	/*
 		// TODO: accept a locale in this method and use that for the format
@@ -102,12 +112,14 @@ func (c instanceContent) UpdatedFriendly() string {
 func handleViewAdminDash(app *App, u *User, w http.ResponseWriter, r *http.Request) error {
 	p := struct {
 		*UserPage
+		*AdminPage
 		Message string
 
 		UsersCount, CollectionsCount, PostsCount int64
 	}{
-		UserPage: NewUserPage(app, r, u, "Admin", nil),
-		Message:  r.FormValue("m"),
+		UserPage:  NewUserPage(app, r, u, "Admin", nil),
+		AdminPage: NewAdminPage(app),
+		Message:   r.FormValue("m"),
 	}
 
 	// Get user stats
@@ -130,12 +142,14 @@ func handleViewAdminMonitor(app *App, u *User, w http.ResponseWriter, r *http.Re
 	updateAppStats()
 	p := struct {
 		*UserPage
+		*AdminPage
 		SysStatus systemStatus
 		Config    config.AppCfg
 
 		Message, ConfigMessage string
 	}{
 		UserPage:  NewUserPage(app, r, u, "Admin", nil),
+		AdminPage: NewAdminPage(app),
 		SysStatus: sysStatus,
 		Config:    app.cfg.App,
 
@@ -150,12 +164,14 @@ func handleViewAdminMonitor(app *App, u *User, w http.ResponseWriter, r *http.Re
 func handleViewAdminSettings(app *App, u *User, w http.ResponseWriter, r *http.Request) error {
 	p := struct {
 		*UserPage
+		*AdminPage
 		Config config.AppCfg
 
 		Message, ConfigMessage string
 	}{
-		UserPage: NewUserPage(app, r, u, "Admin", nil),
-		Config:   app.cfg.App,
+		UserPage:  NewUserPage(app, r, u, "Admin", nil),
+		AdminPage: NewAdminPage(app),
+		Config:    app.cfg.App,
 
 		Message:       r.FormValue("m"),
 		ConfigMessage: r.FormValue("cm"),
@@ -168,6 +184,7 @@ func handleViewAdminSettings(app *App, u *User, w http.ResponseWriter, r *http.R
 func handleViewAdminUsers(app *App, u *User, w http.ResponseWriter, r *http.Request) error {
 	p := struct {
 		*UserPage
+		*AdminPage
 		Config  config.AppCfg
 		Message string
 
@@ -176,9 +193,10 @@ func handleViewAdminUsers(app *App, u *User, w http.ResponseWriter, r *http.Requ
 		TotalUsers int64
 		TotalPages []int
 	}{
-		UserPage: NewUserPage(app, r, u, "Users", nil),
-		Config:   app.cfg.App,
-		Message:  r.FormValue("m"),
+		UserPage:  NewUserPage(app, r, u, "Users", nil),
+		AdminPage: NewAdminPage(app),
+		Config:    app.cfg.App,
+		Message:   r.FormValue("m"),
 	}
 
 	p.TotalUsers = app.db.GetAllUsersCount()
@@ -214,6 +232,7 @@ func handleViewAdminUser(app *App, u *User, w http.ResponseWriter, r *http.Reque
 
 	p := struct {
 		*UserPage
+		*AdminPage
 		Config  config.AppCfg
 		Message string
 
@@ -349,14 +368,16 @@ func handleAdminResetUserPass(app *App, u *User, w http.ResponseWriter, r *http.
 func handleViewAdminPages(app *App, u *User, w http.ResponseWriter, r *http.Request) error {
 	p := struct {
 		*UserPage
+		*AdminPage
 		Config  config.AppCfg
 		Message string
 
 		Pages []*instanceContent
 	}{
-		UserPage: NewUserPage(app, r, u, "Pages", nil),
-		Config:   app.cfg.App,
-		Message:  r.FormValue("m"),
+		UserPage:  NewUserPage(app, r, u, "Pages", nil),
+		AdminPage: NewAdminPage(app),
+		Config:    app.cfg.App,
+		Message:   r.FormValue("m"),
 	}
 
 	var err error
@@ -413,6 +434,7 @@ func handleViewAdminPage(app *App, u *User, w http.ResponseWriter, r *http.Reque
 
 	p := struct {
 		*UserPage
+		*AdminPage
 		Config  config.AppCfg
 		Message string
 
@@ -583,15 +605,16 @@ func handleViewAdminUpdates(app *App, u *User, w http.ResponseWriter, r *http.Re
 
 	p := struct {
 		*UserPage
+		*AdminPage
 		CurReleaseNotesURL    string
 		LastChecked           string
 		LastChecked8601       string
 		LatestVersion         string
 		LatestReleaseURL      string
 		LatestReleaseNotesURL string
-		UpdateAvailable       bool
 	}{
-		UserPage: NewUserPage(app, r, u, "Updates", nil),
+		UserPage:  NewUserPage(app, r, u, "Updates", nil),
+		AdminPage: NewAdminPage(app),
 	}
 	p.CurReleaseNotesURL = wfReleaseNotesURL(p.Version)
 	if app.cfg.App.UpdateChecks {

--- a/admin.go
+++ b/admin.go
@@ -95,9 +95,11 @@ type AdminPage struct {
 }
 
 func NewAdminPage(app *App) *AdminPage {
-	return &AdminPage{
-		UpdateAvailable: app.updates.AreAvailableNoCheck(),
+	ap := &AdminPage{}
+	if app.updates != nil {
+		ap.UpdateAvailable = app.updates.AreAvailableNoCheck()
 	}
+	return ap
 }
 
 func (c instanceContent) UpdatedFriendly() string {

--- a/admin.go
+++ b/admin.go
@@ -245,9 +245,10 @@ func handleViewAdminUser(app *App, u *User, w http.ResponseWriter, r *http.Reque
 		TotalPosts  int64
 		ClearEmail  string
 	}{
-		Config:  app.cfg.App,
-		Message: r.FormValue("m"),
-		Colls:   []inspectedCollection{},
+		AdminPage: NewAdminPage(app),
+		Config:    app.cfg.App,
+		Message:   r.FormValue("m"),
+		Colls:     []inspectedCollection{},
 	}
 
 	var err error

--- a/admin.go
+++ b/admin.go
@@ -583,17 +583,17 @@ func handleViewAdminUpdates(app *App, u *User, w http.ResponseWriter, r *http.Re
 
 	p := struct {
 		*UserPage
-		LastChecked      string
-		LatestVersion    string
-		LatestReleaseURL string
-		UpdateAvailable  bool
+		LastChecked           string
+		LatestVersion         string
+		LatestReleaseNotesURL string
+		UpdateAvailable       bool
 	}{
 		UserPage: NewUserPage(app, r, u, "Updates", nil),
 	}
 	if app.cfg.App.UpdateChecks {
 		p.LastChecked = app.updates.lastCheck.Format("January 2, 2006, 3:04 PM")
 		p.LatestVersion = app.updates.LatestVersion()
-		p.LatestReleaseURL = app.updates.ReleaseURL()
+		p.LatestReleaseNotesURL = app.updates.ReleaseNotesURL()
 		p.UpdateAvailable = app.updates.AreAvailable()
 	}
 

--- a/admin.go
+++ b/admin.go
@@ -586,6 +586,7 @@ func handleViewAdminUpdates(app *App, u *User, w http.ResponseWriter, r *http.Re
 		LastChecked           string
 		LastChecked8601       string
 		LatestVersion         string
+		LatestReleaseURL      string
 		LatestReleaseNotesURL string
 		UpdateAvailable       bool
 	}{
@@ -595,6 +596,7 @@ func handleViewAdminUpdates(app *App, u *User, w http.ResponseWriter, r *http.Re
 		p.LastChecked = app.updates.lastCheck.Format("January 2, 2006, 3:04 PM")
 		p.LastChecked8601 = app.updates.lastCheck.Format("2006-01-02T15:04:05Z")
 		p.LatestVersion = app.updates.LatestVersion()
+		p.LatestReleaseURL = app.updates.ReleaseURL()
 		p.LatestReleaseNotesURL = app.updates.ReleaseNotesURL()
 		p.UpdateAvailable = app.updates.AreAvailable()
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -93,6 +93,7 @@ type (
 
 		// Site functionality
 		Chorus        bool `ini:"chorus"`
+		Forest        bool `ini:"forest"` // The admin cares about the forest, not the trees. Hide unnecessary technical info.
 		DisableDrafts bool `ini:"disable_drafts"`
 
 		// Users

--- a/less/admin.less
+++ b/less/admin.less
@@ -19,7 +19,13 @@ nav#admin {
 		&.selected {
 			background: #dedede;
 			font-weight: bold;
+			.blip {
+				color: black;
+			}
 		}
+	}
+	.blip {
+		font-weight: bold;
 	}
 }
 .pager {

--- a/less/admin.less
+++ b/less/admin.less
@@ -55,3 +55,32 @@ nav#admin {
 		font-size: 0.86em;
 	}
 }
+
+.features {
+	margin: 1em 0;
+
+	div {
+		&:first-child {
+			font-weight: bold;
+		}
+		&+div {
+			padding-left: 1em;
+		}
+
+		p {
+			font-weight: normal;
+			margin: 0.5rem 0;
+			font-size: 0.86em;
+			color: #666;
+		}
+	}
+}
+
+@media (max-width: 600px) {
+	div.row.features {
+		align-items: start;
+	}
+	.features div + div {
+		padding-left: 0;
+	}
+}

--- a/less/admin.less
+++ b/less/admin.less
@@ -48,3 +48,10 @@ nav#admin {
 		}
 	}
 }
+
+.admin-actions {
+	.btn {
+		font-family: @sansFont;
+		font-size: 0.86em;
+	}
+}

--- a/less/admin.less
+++ b/less/admin.less
@@ -13,11 +13,11 @@ nav#admin {
 	display: block;
 	margin: 0.5em 0;
 	a {
-		color: @primary;
-		&:first-child {
-			margin-left: 0;
-		}
+		margin-left: 0;
+		.rounded(.25em);
+		border: 0;
 		&.selected {
+			background: #dedede;
 			font-weight: bold;
 		}
 	}

--- a/less/core.less
+++ b/less/core.less
@@ -1345,6 +1345,11 @@ div.row {
 	}
 }
 
+.check {
+	font-size: 1.125em;
+	color: #71D571;
+}
+
 @media all and (max-width: 450px) {
 	body#post {
 		header {

--- a/less/core.less
+++ b/less/core.less
@@ -868,20 +868,6 @@ input {
 			text-align: center;
 		}
 	}
-	div.features {
-		margin-top: 1.5em;
-		text-align: center;
-		font-size: 0.86em;
-		ul {
-			text-align: left;
-			max-width: 26em;
-			margin-left: auto !important;
-			margin-right: auto !important;
-			li.soon, span.soon {
-				color: lighten(#111, 40%);
-			}
-		}
-	}
 	div.blurbs {
 		>h2 {
 			text-align: center;

--- a/less/core.less
+++ b/less/core.less
@@ -1421,7 +1421,7 @@ div.row {
 }
 
 @media all and (max-width: 600px) {
-	div.row {
+	div.row:not(.admin-actions) {
 		flex-direction: column;
 	}
 	.half {

--- a/less/core.less
+++ b/less/core.less
@@ -1350,6 +1350,11 @@ div.row {
 	color: #71D571;
 }
 
+.ex.failure {
+	font-weight: bold;
+	color: @dangerCol;
+}
+
 @media all and (max-width: 450px) {
 	body#post {
 		header {

--- a/less/core.less
+++ b/less/core.less
@@ -1345,7 +1345,7 @@ div.row {
 	}
 }
 
-.check {
+.check, .blip {
 	font-size: 1.125em;
 	color: #71D571;
 }

--- a/routes.go
+++ b/routes.go
@@ -152,6 +152,8 @@ func InitRoutes(apper Apper, r *mux.Router) *mux.Router {
 	write.HandleFunc("/auth/login", handler.Web(webLogin, UserLevelNoneRequired)).Methods("POST")
 
 	write.HandleFunc("/admin", handler.Admin(handleViewAdminDash)).Methods("GET")
+	write.HandleFunc("/admin/monitor", handler.Admin(handleViewAdminMonitor)).Methods("GET")
+	write.HandleFunc("/admin/settings", handler.Admin(handleViewAdminSettings)).Methods("GET")
 	write.HandleFunc("/admin/users", handler.Admin(handleViewAdminUsers)).Methods("GET")
 	write.HandleFunc("/admin/user/{username}", handler.Admin(handleViewAdminUser)).Methods("GET")
 	write.HandleFunc("/admin/user/{username}/status", handler.Admin(handleAdminToggleUserStatus)).Methods("POST")

--- a/templates/user/admin.tmpl
+++ b/templates/user/admin.tmpl
@@ -35,6 +35,14 @@ form dt {
 p.docs {
 	font-size: 0.86em;
 }
+.stats {
+	font-size: 1.2em;
+	margin: 1em 0;
+}
+.num {
+	font-weight: bold;
+	font-size: 1.5em;
+}
 </style>
 
 <div class="content-container snug">
@@ -42,142 +50,12 @@ p.docs {
 
 	{{if .Message}}<p>{{.Message}}</p>{{end}}
 
-	<h2>On this page</h2>
-	<ul class="pagenav">
-		<li><a href="#config">Configuration</a></li>
-		<li><a href="#monitor">Application monitor</a></li>
-	</ul>
-
-	<h2>Resources</h2>
-	<ul class="pagenav">
-		<li><a href="https://writefreely.org/docs/{{.OfficialVersion}}/admin">Admin Guide</a></li>
-	</ul>
-
-	<hr />
-
-	<h2><a name="config"></a>App Configuration</h2>
-	<p class="docs">Read more in the <a href="https://writefreely.org/docs/{{.OfficialVersion}}/admin/config">configuration docs</a>.</p>
-
-	{{if .ConfigMessage}}<p class="success" style="text-align: center">{{.ConfigMessage}}</p>{{end}}
-
-	<form action="/admin/update/config" method="post">
-	<div class="ui attached table segment">
-		<dl class="dl-horizontal admin-dl-horizontal">
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}>Site Name</dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="text" name="site_name" id="site_name" class="inline" value="{{.Config.SiteName}}" style="width: 14em;" /></dd>
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}>Site Description</dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="text" name="site_desc" id="site_desc" class="inline" value="{{.Config.SiteDesc}}" style="width: 14em;" /></dd>
-			<dt>Host</dt>
-			<dd>{{.Config.Host}}</dd>
-			<dt>User Mode</dt>
-			<dd>{{if .Config.SingleUser}}Single user{{else}}Multiple users{{end}}</dd>
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}>Landing Page</dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="text" name="landing" id="landing" class="inline" value="{{.Config.Landing}}" style="width: 14em;" /></dd>
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="open_registration">Open Registrations</label></dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="checkbox" name="open_registration" id="open_registration" {{if .Config.OpenRegistration}}checked="checked"{{end}} /></dd>
-			<dt><label for="min_username_len">Minimum Username Length</label></dt>
-			<dd><input type="number" name="min_username_len" id="min_username_len" class="inline" min="1" max="100" value="{{.Config.MinUsernameLen}}" /></dd>
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="max_blogs">Maximum Blogs per User</label></dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="number" name="max_blogs" id="max_blogs" class="inline" min="1" value="{{.Config.MaxBlogs}}" /></dd>
-			<dt><label for="federation">Federation</label></dt>
-			<dd><input type="checkbox" name="federation" id="federation" {{if .Config.Federation}}checked="checked"{{end}} /></dd>
-			<dt><label for="public_stats">Public Stats</label></dt>
-			<dd><input type="checkbox" name="public_stats" id="public_stats" {{if .Config.PublicStats}}checked="checked"{{end}} /></dd>
-			<dt><label for="private">Private Instance</label></dt>
-			<dd><input type="checkbox" name="private" id="private" {{if .Config.Private}}checked="checked"{{end}} /></dd>
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="local_timeline">Local Timeline</label></dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="checkbox" name="local_timeline" id="local_timeline" {{if .Config.LocalTimeline}}checked="checked"{{end}} /></dd>
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="user_invites">Allow sending invitations by</label></dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}>
-				<select name="user_invites" id="user_invites">
-					<option value="none" {{if eq .Config.UserInvites ""}}selected="selected"{{end}}>No one</option>
-					<option value="user" {{if eq .Config.UserInvites "user"}}selected="selected"{{end}}>Users</option>
-					<option value="admin" {{if eq .Config.UserInvites "admin"}}selected="selected"{{end}}>Admins</option>
-				</select>
-			</dd>
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="default_visibility">Default blog visibility</label></dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}>
-				<select name="default_visibility" id="default_visibility">
-					<option value="unlisted" {{if eq .Config.DefaultVisibility "unlisted"}}selected="selected"{{end}}>Unlisted</option>
-					<option value="public" {{if eq .Config.DefaultVisibility "public"}}selected="selected"{{end}}>Public</option>
-					<option value="private" {{if eq .Config.DefaultVisibility "private"}}selected="selected"{{end}}>Private</option>
-				</select>
-			</dd>
-		</dl>
-		<input type="submit" value="Save Configuration" />
+	<div class="row stats">
+		<div><span class="num">{{largeNumFmt .UsersCount}}</span> {{pluralize "user" "users" .UsersCount}}</div>
+		<div><span class="num">{{largeNumFmt .CollectionsCount}}</span> {{pluralize "blog" "blogs" .CollectionsCount}}</div>
+		<div><span class="num">{{largeNumFmt .PostsCount}}</span> {{pluralize "post" "posts" .PostsCount}}</div>
 	</div>
-	</form>
 
-	<hr />
-
-	<h2><a name="monitor"></a>Application</h2>
-
-	<div class="ui attached table segment">
-		<dl class="dl-horizontal admin-dl-horizontal">
-			<dt>WriteFreely</dt>
-			<dd>{{.Version}}</dd>
-			<dt>Server Uptime</dt>
-			<dd>{{.SysStatus.Uptime}}</dd>
-			<dt>Current Goroutines</dt>
-			<dd>{{.SysStatus.NumGoroutine}}</dd>
-			<div class="ui divider"></div>
-			<dt>Current memory usage</dt>
-			<dd>{{.SysStatus.MemAllocated}}</dd>
-			<dt>Total mem allocated</dt>
-			<dd>{{.SysStatus.MemTotal}}</dd>
-			<dt>Memory obtained</dt>
-			<dd>{{.SysStatus.MemSys}}</dd>
-			<dt>Pointer lookup times</dt>
-			<dd>{{.SysStatus.Lookups}}</dd>
-			<dt>Memory allocate times</dt>
-			<dd>{{.SysStatus.MemMallocs}}</dd>
-			<dt>Memory free times</dt>
-			<dd>{{.SysStatus.MemFrees}}</dd>
-			<div class="ui divider"></div>
-			<dt>Current heap usage</dt>
-			<dd>{{.SysStatus.HeapAlloc}}</dd>
-			<dt>Heap memory obtained</dt>
-			<dd>{{.SysStatus.HeapSys}}</dd>
-			<dt>Heap memory idle</dt>
-			<dd>{{.SysStatus.HeapIdle}}</dd>
-			<dt>Heap memory in use</dt>
-			<dd>{{.SysStatus.HeapInuse}}</dd>
-			<dt>Heap memory released</dt>
-			<dd>{{.SysStatus.HeapReleased}}</dd>
-			<dt>Heap objects</dt>
-			<dd>{{.SysStatus.HeapObjects}}</dd>
-			<div class="ui divider"></div>
-			<dt>Bootstrap stack usage</dt>
-			<dd>{{.SysStatus.StackInuse}}</dd>
-			<dt>Stack memory obtained</dt>
-			<dd>{{.SysStatus.StackSys}}</dd>
-			<dt>MSpan structures in use</dt>
-			<dd>{{.SysStatus.MSpanInuse}}</dd>
-			<dt>MSpan structures obtained</dt>
-			<dd>{{.SysStatus.HeapSys}}</dd>
-			<dt>MCache structures in use</dt>
-			<dd>{{.SysStatus.MCacheInuse}}</dd>
-			<dt>MCache structures obtained</dt>
-			<dd>{{.SysStatus.MCacheSys}}</dd>
-			<dt>Profiling bucket hash table obtained</dt>
-			<dd>{{.SysStatus.BuckHashSys}}</dd>
-			<dt>GC metadata obtained</dt>
-			<dd>{{.SysStatus.GCSys}}</dd>
-			<dt>Other system allocation obtained</dt>
-			<dd>{{.SysStatus.OtherSys}}</dd>
-			<div class="ui divider"></div>
-			<dt>Next GC recycle</dt>
-			<dd>{{.SysStatus.NextGC}}</dd>
-			<dt>Since last GC</dt>
-			<dd>{{.SysStatus.LastGC}}</dd>
-			<dt>Total GC pause</dt>
-			<dd>{{.SysStatus.PauseTotalNs}}</dd>
-			<dt>Last GC pause</dt>
-			<dd>{{.SysStatus.PauseNs}}</dd>
-			<dt>GC times</dt>
-			<dd>{{.SysStatus.NumGC}}</dd>
-		</dl>
-	</div>
 </div>
 
 <script>

--- a/templates/user/admin/app-settings.tmpl
+++ b/templates/user/admin/app-settings.tmpl
@@ -24,55 +24,124 @@ p.docs {
 
 	{{if .ConfigMessage}}<p class="success" style="text-align: center">{{.ConfigMessage}}</p>{{end}}
 
-	<p class="docs">Read more in the <a href="https://writefreely.org/docs/{{.OfficialVersion}}/admin/config">configuration docs</a>.</p>
-
 	<form action="/admin/update/config" method="post">
-	<div class="ui attached table segment">
-		<dl class="dl-horizontal admin-dl-horizontal">
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}>Site Name</dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="text" name="site_name" id="site_name" class="inline" value="{{.Config.SiteName}}" style="width: 14em;" /></dd>
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}>Site Description</dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="text" name="site_desc" id="site_desc" class="inline" value="{{.Config.SiteDesc}}" style="width: 14em;" /></dd>
-			<dt>Host</dt>
-			<dd>{{.Config.Host}}</dd>
-			<dt>User Mode</dt>
-			<dd>{{if .Config.SingleUser}}Single user{{else}}Multiple users{{end}}</dd>
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}>Landing Page</dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="text" name="landing" id="landing" class="inline" value="{{.Config.Landing}}" style="width: 14em;" /></dd>
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="open_registration">Open Registrations</label></dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="checkbox" name="open_registration" id="open_registration" {{if .Config.OpenRegistration}}checked="checked"{{end}} /></dd>
-			<dt><label for="min_username_len">Minimum Username Length</label></dt>
-			<dd><input type="number" name="min_username_len" id="min_username_len" class="inline" min="1" max="100" value="{{.Config.MinUsernameLen}}" /></dd>
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="max_blogs">Maximum Blogs per User</label></dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="number" name="max_blogs" id="max_blogs" class="inline" min="1" value="{{.Config.MaxBlogs}}" /></dd>
-			<dt><label for="federation">Federation</label></dt>
-			<dd><input type="checkbox" name="federation" id="federation" {{if .Config.Federation}}checked="checked"{{end}} /></dd>
-			<dt><label for="public_stats">Public Stats</label></dt>
-			<dd><input type="checkbox" name="public_stats" id="public_stats" {{if .Config.PublicStats}}checked="checked"{{end}} /></dd>
-			<dt><label for="private">Private Instance</label></dt>
-			<dd><input type="checkbox" name="private" id="private" {{if .Config.Private}}checked="checked"{{end}} /></dd>
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="local_timeline">Local Timeline</label></dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="checkbox" name="local_timeline" id="local_timeline" {{if .Config.LocalTimeline}}checked="checked"{{end}} /></dd>
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="user_invites">Allow sending invitations by</label></dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}>
+		<div class="features row">
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}>
+				Site Title
+				<p>Your public site name.</p>
+			</div>
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}><input type="text" name="site_name" id="site_name" class="inline" value="{{.Config.SiteName}}" style="width: 14em;"/></div>
+		</div>
+		<div class="features row">
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}>
+				Site Description
+				<p>Describe your site &mdash; this shows in your site's metadata.</p>
+			</div>
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}><input type="text" name="site_desc" id="site_desc" class="inline" value="{{.Config.SiteDesc}}" style="width: 14em;"/></div>
+		</div>
+		<div class="features row">
+			<div>
+				Host
+				<p>The address where your site lives.</p>
+			</div>
+			<div>{{.Config.Host}}</div>
+		</div>
+		<div class="features row">
+			<div>
+				Community Mode
+				<p>Whether your site is made for one person or many.</p>
+			</div>
+			<div>{{if .Config.SingleUser}}Single user{{else}}Multiple users{{end}}</div>
+		</div>
+		<div class="features row">
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}>
+				Landing Page
+				<p>The page that logged-out visitors will see first. This should be a path, e.g. <code>/read</code></p>
+			</div>
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}><input type="text" name="landing" id="landing" class="inline" value="{{.Config.Landing}}" style="width: 14em;"/></div>
+		</div>
+		<div class="features row">
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}><label for="open_registration">
+					Open Registrations
+					<p>Whether or not registration is open to anyone who visits the site.</p>
+				</label></div>
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}><input type="checkbox" name="open_registration" id="open_registration" {{if .Config.OpenRegistration}}checked="checked"{{end}} />
+			</div>
+		</div>
+		<div class="features row">
+			<div><label for="min_username_len">
+					Minimum Username Length
+					<p>The minimum number of characters allowed in a username. (Recommended: 2 or more.)</p>
+				</label></div>
+			<div><input type="number" name="min_username_len" id="min_username_len" class="inline" min="1" max="100" value="{{.Config.MinUsernameLen}}"/></div>
+		</div>
+		<div class="features row">
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}><label for="max_blogs">
+					Maximum Blogs per User
+					<p>Keep things simple by setting this to <strong>1</strong>, unlimited by setting to <strong>0</strong>, or pick another amount.</p>
+				</label></div>
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}><input type="number" name="max_blogs" id="max_blogs" class="inline" min="0" value="{{.Config.MaxBlogs}}"/></div>
+		</div>
+		<div class="features row">
+			<div><label for="federation">
+					Federation
+					<p>Enable accounts on this site to propagate their posts via the ActivityPub protocol.</p>
+				</label></div>
+			<div><input type="checkbox" name="federation" id="federation" {{if .Config.Federation}}checked="checked"{{end}} /></div>
+		</div>
+		<div class="features row">
+			<div><label for="public_stats">
+					Public Stats
+					<p>Publicly display the number of users and posts on your <strong>About</strong> page.</p>
+				</label></div>
+			<div><input type="checkbox" name="public_stats" id="public_stats" {{if .Config.PublicStats}}checked="checked"{{end}} /></div>
+		</div>
+		<div class="features row">
+			<div><label for="private">
+					Private Instance
+					<p>Make this instance accessible only to those with an account.</p>
+				</label></div>
+			<div><input type="checkbox" name="private" id="private" {{if .Config.Private}}checked="checked"{{end}} /></div>
+		</div>
+		<div class="features row">
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}><label for="local_timeline">
+					Reader
+					<p>Show a feed of user posts for anyone who chooses to share there.</p>
+				</label></div>
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}><input type="checkbox" name="local_timeline" id="local_timeline" {{if .Config.LocalTimeline}}checked="checked"{{end}} /></div>
+		</div>
+		<div class="features row">
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}><label for="user_invites">
+					Allow invitations from...
+					<p>Choose who on this instance can invite new people.</p>
+				</label></div>
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}>
 				<select name="user_invites" id="user_invites">
 					<option value="none" {{if eq .Config.UserInvites ""}}selected="selected"{{end}}>No one</option>
-					<option value="user" {{if eq .Config.UserInvites "user"}}selected="selected"{{end}}>Users</option>
-					<option value="admin" {{if eq .Config.UserInvites "admin"}}selected="selected"{{end}}>Admins</option>
+					<option value="admin" {{if eq .Config.UserInvites "admin"}}selected="selected"{{end}}>Only Admins</option>
+					<option value="user" {{if eq .Config.UserInvites "user"}}selected="selected"{{end}}>All Users</option>
 				</select>
-			</dd>
-			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="default_visibility">Default blog visibility</label></dt>
-			<dd{{if .Config.SingleUser}} class="invisible"{{end}}>
+			</div>
+		</div>
+		<div class="features row">
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}><label for="default_visibility">
+					Default blog visibility
+					<p>The default setting for new accounts and blogs.</p>
+				</label></div>
+			<div{{if .Config.SingleUser}} class="invisible"{{end}}>
 				<select name="default_visibility" id="default_visibility">
 					<option value="unlisted" {{if eq .Config.DefaultVisibility "unlisted"}}selected="selected"{{end}}>Unlisted</option>
 					<option value="public" {{if eq .Config.DefaultVisibility "public"}}selected="selected"{{end}}>Public</option>
 					<option value="private" {{if eq .Config.DefaultVisibility "private"}}selected="selected"{{end}}>Private</option>
 				</select>
-			</dd>
-		</dl>
-		<input type="submit" value="Save Settings" />
-	</div>
+			</div>
+		</div>
+		<div class="features row">
+			<input type="submit" value="Save Settings" />
+		</div>
 	</form>
+
+	<p class="docs">Still have questions? Read more details in the <a href="https://writefreely.org/docs/{{.OfficialVersion}}/admin/config">configuration docs</a>.</p>
 </div>
 
 <script>

--- a/templates/user/admin/app-settings.tmpl
+++ b/templates/user/admin/app-settings.tmpl
@@ -1,0 +1,85 @@
+{{define "app-settings"}}
+{{template "header" .}}
+
+<style type="text/css">
+h2 {font-weight: normal;}
+form {
+	margin: 0 0 2em;
+}
+form dt {
+	line-height: inherit;
+}
+.invisible {
+	display: none;
+}
+p.docs {
+	font-size: 0.86em;
+}
+</style>
+
+<div class="content-container snug">
+	{{template "admin-header" .}}
+
+	{{if .Message}}<p><a name="config"></a>{{.Message}}</p>{{end}}
+
+	{{if .ConfigMessage}}<p class="success" style="text-align: center">{{.ConfigMessage}}</p>{{end}}
+
+	<p class="docs">Read more in the <a href="https://writefreely.org/docs/{{.OfficialVersion}}/admin/config">configuration docs</a>.</p>
+
+	<form action="/admin/update/config" method="post">
+	<div class="ui attached table segment">
+		<dl class="dl-horizontal admin-dl-horizontal">
+			<dt{{if .Config.SingleUser}} class="invisible"{{end}}>Site Name</dt>
+			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="text" name="site_name" id="site_name" class="inline" value="{{.Config.SiteName}}" style="width: 14em;" /></dd>
+			<dt{{if .Config.SingleUser}} class="invisible"{{end}}>Site Description</dt>
+			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="text" name="site_desc" id="site_desc" class="inline" value="{{.Config.SiteDesc}}" style="width: 14em;" /></dd>
+			<dt>Host</dt>
+			<dd>{{.Config.Host}}</dd>
+			<dt>User Mode</dt>
+			<dd>{{if .Config.SingleUser}}Single user{{else}}Multiple users{{end}}</dd>
+			<dt{{if .Config.SingleUser}} class="invisible"{{end}}>Landing Page</dt>
+			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="text" name="landing" id="landing" class="inline" value="{{.Config.Landing}}" style="width: 14em;" /></dd>
+			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="open_registration">Open Registrations</label></dt>
+			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="checkbox" name="open_registration" id="open_registration" {{if .Config.OpenRegistration}}checked="checked"{{end}} /></dd>
+			<dt><label for="min_username_len">Minimum Username Length</label></dt>
+			<dd><input type="number" name="min_username_len" id="min_username_len" class="inline" min="1" max="100" value="{{.Config.MinUsernameLen}}" /></dd>
+			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="max_blogs">Maximum Blogs per User</label></dt>
+			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="number" name="max_blogs" id="max_blogs" class="inline" min="1" value="{{.Config.MaxBlogs}}" /></dd>
+			<dt><label for="federation">Federation</label></dt>
+			<dd><input type="checkbox" name="federation" id="federation" {{if .Config.Federation}}checked="checked"{{end}} /></dd>
+			<dt><label for="public_stats">Public Stats</label></dt>
+			<dd><input type="checkbox" name="public_stats" id="public_stats" {{if .Config.PublicStats}}checked="checked"{{end}} /></dd>
+			<dt><label for="private">Private Instance</label></dt>
+			<dd><input type="checkbox" name="private" id="private" {{if .Config.Private}}checked="checked"{{end}} /></dd>
+			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="local_timeline">Local Timeline</label></dt>
+			<dd{{if .Config.SingleUser}} class="invisible"{{end}}><input type="checkbox" name="local_timeline" id="local_timeline" {{if .Config.LocalTimeline}}checked="checked"{{end}} /></dd>
+			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="user_invites">Allow sending invitations by</label></dt>
+			<dd{{if .Config.SingleUser}} class="invisible"{{end}}>
+				<select name="user_invites" id="user_invites">
+					<option value="none" {{if eq .Config.UserInvites ""}}selected="selected"{{end}}>No one</option>
+					<option value="user" {{if eq .Config.UserInvites "user"}}selected="selected"{{end}}>Users</option>
+					<option value="admin" {{if eq .Config.UserInvites "admin"}}selected="selected"{{end}}>Admins</option>
+				</select>
+			</dd>
+			<dt{{if .Config.SingleUser}} class="invisible"{{end}}><label for="default_visibility">Default blog visibility</label></dt>
+			<dd{{if .Config.SingleUser}} class="invisible"{{end}}>
+				<select name="default_visibility" id="default_visibility">
+					<option value="unlisted" {{if eq .Config.DefaultVisibility "unlisted"}}selected="selected"{{end}}>Unlisted</option>
+					<option value="public" {{if eq .Config.DefaultVisibility "public"}}selected="selected"{{end}}>Public</option>
+					<option value="private" {{if eq .Config.DefaultVisibility "private"}}selected="selected"{{end}}>Private</option>
+				</select>
+			</dd>
+		</dl>
+		<input type="submit" value="Save Settings" />
+	</div>
+	</form>
+</div>
+
+<script>
+history.replaceState(null, "", "/admin/settings"+window.location.hash);
+</script>
+
+{{template "footer" .}}
+
+{{template "body-end" .}}
+{{end}}

--- a/templates/user/admin/app-updates.tmpl
+++ b/templates/user/admin/app-updates.tmpl
@@ -15,7 +15,11 @@
 	{{template "admin-header" .}}
 
 {{ if .UpdateChecks }}
-	{{if not .UpdateAvailable}}
+	{{if .CheckFailed}}
+		<p class="intro"><span class="ex failure">&times;</span> Automated update check failed.</p>
+		<p>Installed version: <strong>{{.Version}}</strong> (<a href="{{.CurReleaseNotesURL}}" target="changelog-wf">release notes</a>).</p>
+		<p>Learn about latest releases on the <a href="https://blog.writefreely.org/tag:release" target="changelog-wf">WriteFreely blog</a> or <a href="https://discuss.write.as/c/writefreely/updates" target="forum-wf">forum</a>.</p>
+	{{else if not .UpdateAvailable}}
 		<p class="intro"><span class="check">&check;</span> WriteFreely is <strong>up to date</strong>.</p>
 		<p>Installed version: <strong>{{.Version}}</strong> (<a href="{{.LatestReleaseNotesURL}}" target="changelog-wf">release notes</a>).</p>
     {{else}}

--- a/templates/user/admin/app-updates.tmpl
+++ b/templates/user/admin/app-updates.tmpl
@@ -15,7 +15,14 @@
     For details on features, bug fixes or notes on upgrading, <a href="{{.LatestReleaseNotesURL}}">read the release notes</a>.
   </section>
   {{end}}
-  <p>Last checked at: {{.LastChecked}}. <a href="/admin/updates?check=now">Check now</a>.</p>
+	<p>Last checked at: <time class="dt-published" datetime="{{.LastChecked8601}}">{{.LastChecked}}</time>. <a href="/admin/updates?check=now">Check now</a>.</p>
+
+	<script>
+	// Code modified from /js/localdate.js
+	var displayEl = document.querySelector("time");
+	var d = new Date(displayEl.getAttribute("datetime"));
+	displayEl.textContent = d.toLocaleDateString(navigator.language || "en-US", { dateStyle: 'long', timeStyle: 'short' });
+	</script>
 
 {{template "footer" .}}
 

--- a/templates/user/admin/app-updates.tmpl
+++ b/templates/user/admin/app-updates.tmpl
@@ -12,7 +12,7 @@
   {{else}}
   <p class="alert info">WriteFreely {{.LatestVersion}} is available.</p>
   <section class="changelog">
-    For details on features, bug fixes or notes on upgrading, <a href="{{.LatestReleaseURL}}">read the release notes</a>.
+    For details on features, bug fixes or notes on upgrading, <a href="{{.LatestReleaseNotesURL}}">read the release notes</a>.
   </section>
   {{end}}
   <p>Last checked at: {{.LastChecked}}. <a href="/admin/updates?check=now">Check now</a>.</p>

--- a/templates/user/admin/app-updates.tmpl
+++ b/templates/user/admin/app-updates.tmpl
@@ -2,20 +2,24 @@
 {{template "header" .}}
 
 <style type="text/css">
+	p.intro {
+		text-align: left;
+	}
 </style>
 
 <div class="content-container snug">
 	{{template "admin-header" .}}
 
 	{{if not .UpdateAvailable}}
-  <p class="alert info">WriteFreely is up to date.</p>
-  {{else}}
-  <p class="alert info">WriteFreely {{.LatestVersion}} is available.</p>
-  <section class="changelog">
-    For details on features, bug fixes or notes on upgrading, <a href="{{.LatestReleaseNotesURL}}">read the release notes</a>.
-  </section>
-  {{end}}
-	<p>Last checked at: <time class="dt-published" datetime="{{.LastChecked8601}}">{{.LastChecked}}</time>. <a href="/admin/updates?check=now">Check now</a>.</p>
+		<p class="intro"><span class="check">&check;</span> WriteFreely is <strong>up to date</strong>.</p>
+		<p>Installed version: <strong>{{.Version}}</strong> (<a href="{{.LatestReleaseNotesURL}}" target="changelog-wf">release notes</a>).</p>
+    {{else}}
+		<p class="intro">A new version of WriteFreely is available! <a href="{{.LatestReleaseURL}}" target="download-wf" style="font-weight: bold;">Get {{.LatestVersion}}</a></p>
+		<p class="changelog">
+			<a href="{{.LatestReleaseNotesURL}}" target="changelog-wf">Read the release notes</a> for details on features, bug fixes, and notes on upgrading from your current version, <strong>{{.Version}}</strong>.
+		</p>
+	{{end}}
+	<p style="font-size: 0.86em;"><em>Last checked</em>: <time class="dt-published" datetime="{{.LastChecked8601}}">{{.LastChecked}}</time>. <a href="/admin/updates?check=now">Check now</a>.</p>
 
 	<script>
 	// Code modified from /js/localdate.js

--- a/templates/user/admin/app-updates.tmpl
+++ b/templates/user/admin/app-updates.tmpl
@@ -5,11 +5,16 @@
 	p.intro {
 		text-align: left;
 	}
+	p.disabled {
+		font-style: italic;
+		color: #999;
+	}
 </style>
 
 <div class="content-container snug">
 	{{template "admin-header" .}}
 
+{{ if .UpdateChecks }}
 	{{if not .UpdateAvailable}}
 		<p class="intro"><span class="check">&check;</span> WriteFreely is <strong>up to date</strong>.</p>
 		<p>Installed version: <strong>{{.Version}}</strong> (<a href="{{.LatestReleaseNotesURL}}" target="changelog-wf">release notes</a>).</p>
@@ -27,6 +32,11 @@
 	var d = new Date(displayEl.getAttribute("datetime"));
 	displayEl.textContent = d.toLocaleDateString(navigator.language || "en-US", { dateStyle: 'long', timeStyle: 'short' });
 	</script>
+{{ else }}
+	<p class="intro disabled">Automated update checks are disabled.</p>
+	<p>Installed version: <strong>{{.Version}}</strong> (<a href="{{.CurReleaseNotesURL}}" target="changelog-wf">release notes</a>).</p>
+	<p>Learn about latest releases on the <a href="https://blog.writefreely.org/tag:release" target="changelog-wf">WriteFreely blog</a> or <a href="https://discuss.write.as/c/writefreely/updates" target="forum-wf">forum</a>.</p>
+{{ end }}
 
 {{template "footer" .}}
 

--- a/templates/user/admin/monitor.tmpl
+++ b/templates/user/admin/monitor.tmpl
@@ -1,0 +1,105 @@
+{{define "monitor"}}
+{{template "header" .}}
+
+<style type="text/css">
+h2 {font-weight: normal;}
+.ui.divider:not(.vertical):not(.horizontal) {
+	border-top: 1px solid rgba(34,36,38,.15);
+	border-bottom: 1px solid rgba(255,255,255,.1);
+}
+.ui.divider {
+	margin: 1rem 0;
+	line-height: 1;
+	height: 0;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: .05em;
+	color: rgba(0,0,0,.85);
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	-webkit-tap-highlight-color: transparent;
+	font-size: 1rem;
+}
+</style>
+
+<div class="content-container snug">
+	{{template "admin-header" .}}
+
+	{{if .Message}}<p>{{.Message}}</p>{{end}}
+
+	<h2><a name="monitor"></a>Application Monitor</h2>
+
+	<div class="ui attached table segment">
+		<dl class="dl-horizontal admin-dl-horizontal">
+			<dt>WriteFreely</dt>
+			<dd>{{.Version}}</dd>
+			<dt>Server Uptime</dt>
+			<dd>{{.SysStatus.Uptime}}</dd>
+			<dt>Current Goroutines</dt>
+			<dd>{{.SysStatus.NumGoroutine}}</dd>
+			<div class="ui divider"></div>
+			<dt>Current memory usage</dt>
+			<dd>{{.SysStatus.MemAllocated}}</dd>
+			<dt>Total mem allocated</dt>
+			<dd>{{.SysStatus.MemTotal}}</dd>
+			<dt>Memory obtained</dt>
+			<dd>{{.SysStatus.MemSys}}</dd>
+			<dt>Pointer lookup times</dt>
+			<dd>{{.SysStatus.Lookups}}</dd>
+			<dt>Memory allocate times</dt>
+			<dd>{{.SysStatus.MemMallocs}}</dd>
+			<dt>Memory free times</dt>
+			<dd>{{.SysStatus.MemFrees}}</dd>
+			<div class="ui divider"></div>
+			<dt>Current heap usage</dt>
+			<dd>{{.SysStatus.HeapAlloc}}</dd>
+			<dt>Heap memory obtained</dt>
+			<dd>{{.SysStatus.HeapSys}}</dd>
+			<dt>Heap memory idle</dt>
+			<dd>{{.SysStatus.HeapIdle}}</dd>
+			<dt>Heap memory in use</dt>
+			<dd>{{.SysStatus.HeapInuse}}</dd>
+			<dt>Heap memory released</dt>
+			<dd>{{.SysStatus.HeapReleased}}</dd>
+			<dt>Heap objects</dt>
+			<dd>{{.SysStatus.HeapObjects}}</dd>
+			<div class="ui divider"></div>
+			<dt>Bootstrap stack usage</dt>
+			<dd>{{.SysStatus.StackInuse}}</dd>
+			<dt>Stack memory obtained</dt>
+			<dd>{{.SysStatus.StackSys}}</dd>
+			<dt>MSpan structures in use</dt>
+			<dd>{{.SysStatus.MSpanInuse}}</dd>
+			<dt>MSpan structures obtained</dt>
+			<dd>{{.SysStatus.HeapSys}}</dd>
+			<dt>MCache structures in use</dt>
+			<dd>{{.SysStatus.MCacheInuse}}</dd>
+			<dt>MCache structures obtained</dt>
+			<dd>{{.SysStatus.MCacheSys}}</dd>
+			<dt>Profiling bucket hash table obtained</dt>
+			<dd>{{.SysStatus.BuckHashSys}}</dd>
+			<dt>GC metadata obtained</dt>
+			<dd>{{.SysStatus.GCSys}}</dd>
+			<dt>Other system allocation obtained</dt>
+			<dd>{{.SysStatus.OtherSys}}</dd>
+			<div class="ui divider"></div>
+			<dt>Next GC recycle</dt>
+			<dd>{{.SysStatus.NextGC}}</dd>
+			<dt>Since last GC</dt>
+			<dd>{{.SysStatus.LastGC}}</dd>
+			<dt>Total GC pause</dt>
+			<dd>{{.SysStatus.PauseTotalNs}}</dd>
+			<dt>Last GC pause</dt>
+			<dd>{{.SysStatus.PauseNs}}</dd>
+			<dt>GC times</dt>
+			<dd>{{.SysStatus.NumGC}}</dd>
+		</dl>
+	</div>
+</div>
+
+{{template "footer" .}}
+
+{{template "body-end" .}}
+{{end}}

--- a/templates/user/admin/users.tmpl
+++ b/templates/user/admin/users.tmpl
@@ -4,7 +4,10 @@
 <div class="snug content-container">
 	{{template "admin-header" .}}
 
-	<h2 id="posts-header" style="display: flex; justify-content: space-between;">Users <span style="font-style: italic; font-size: 0.75em;">{{.TotalUsers}} total</span></h2>
+	<div class="row admin-actions" style="justify-content: space-between;">
+		<span style="font-style: italic; font-size: 1.2em">{{.TotalUsers}} {{pluralize "user" "users" .TotalUsers}}</span>
+		<a class="btn cta" href="/me/invites">+ Invite people</a>
+	</div>
 
 	<table class="classy export" style="width:100%">
 		<tr>

--- a/templates/user/admin/users.tmpl
+++ b/templates/user/admin/users.tmpl
@@ -4,7 +4,7 @@
 <div class="snug content-container">
 	{{template "admin-header" .}}
 
-	<h2 id="posts-header" style="display: flex; justify-content: space-between;">Users <span style="font-style: italic; font-size: 0.75em;">{{.TotalUsers}} total</strong></h2>
+	<h2 id="posts-header" style="display: flex; justify-content: space-between;">Users <span style="font-style: italic; font-size: 0.75em;">{{.TotalUsers}} total</span></h2>
 
 	<table class="classy export" style="width:100%">
 		<tr>

--- a/templates/user/admin/view-user.tmpl
+++ b/templates/user/admin/view-user.tmpl
@@ -71,8 +71,7 @@ input.copy-text {
 		</tr>
 		<tr>
 			<form action="/admin/user/{{.User.Username}}/status" method="POST" {{if not .User.IsSilenced}}onsubmit="return confirmSilence()"{{end}}>
-				<a id="status"/>
-				<th>Status</th>
+				<th><a id="status"></a>Status</th>
 				<td class="active-silence">
 				{{if .User.IsSilenced}}
 					<p>Silenced</p>

--- a/templates/user/include/header.tmpl
+++ b/templates/user/include/header.tmpl
@@ -104,7 +104,9 @@
 		<a href="/admin/users" {{if eq .Path "/admin/users"}}class="selected"{{end}}>Users</a>
 		<a href="/admin/pages" {{if eq .Path "/admin/pages"}}class="selected"{{end}}>Pages</a>
 		{{end}}
+		{{if not .Forest}}
 		<a href="/admin/monitor" {{if eq .Path "/admin/monitor"}}class="selected"{{end}}>Monitor</a>
+		{{end}}
 	</nav>
 </header>
 {{end}}

--- a/templates/user/include/header.tmpl
+++ b/templates/user/include/header.tmpl
@@ -103,7 +103,7 @@
 		{{if not .SingleUser}}
 		<a href="/admin/users" {{if eq .Path "/admin/users"}}class="selected"{{end}}>Users</a>
 		<a href="/admin/pages" {{if eq .Path "/admin/pages"}}class="selected"{{end}}>Pages</a>
-		{{if .UpdateChecks}}<a href="/admin/updates" {{if eq .Path "/admin/updates"}}class="selected"{{end}}>Updates</a>{{end}}
+		{{if .UpdateChecks}}<a href="/admin/updates" {{if eq .Path "/admin/updates"}}class="selected"{{end}}>Updates{{if .UpdateAvailable}}<span class="blip">!</span>{{end}}</a>{{end}}
 		{{end}}
 		{{if not .Forest}}
 		<a href="/admin/monitor" {{if eq .Path "/admin/monitor"}}class="selected"{{end}}>Monitor</a>

--- a/templates/user/include/header.tmpl
+++ b/templates/user/include/header.tmpl
@@ -97,12 +97,14 @@
 {{define "admin-header"}}
 <header class="admin">
 	<h1>Admin</h1>
-	<nav id="admin">
+	<nav id="admin" class="pager">
 		<a href="/admin" {{if eq .Path "/admin"}}class="selected"{{end}}>Dashboard</a>
+		<a href="/admin/settings" {{if eq .Path "/admin/settings"}}class="selected"{{end}}>Settings</a>
 		{{if not .SingleUser}}
 		<a href="/admin/users" {{if eq .Path "/admin/users"}}class="selected"{{end}}>Users</a>
 		<a href="/admin/pages" {{if eq .Path "/admin/pages"}}class="selected"{{end}}>Pages</a>
 		{{end}}
+		<a href="/admin/monitor" {{if eq .Path "/admin/monitor"}}class="selected"{{end}}>Monitor</a>
 	</nav>
 </header>
 {{end}}

--- a/updates.go
+++ b/updates.go
@@ -30,6 +30,7 @@ type updatesCache struct {
 	lastCheck      time.Time
 	latestVersion  string
 	currentVersion string
+	checkError     error
 }
 
 // CheckNow asks for the latest released version of writefreely and updates
@@ -38,11 +39,12 @@ type updatesCache struct {
 func (uc *updatesCache) CheckNow() error {
 	uc.mu.Lock()
 	defer uc.mu.Unlock()
+	uc.lastCheck = time.Now()
 	latestRemote, err := newVersionCheck()
 	if err != nil {
+		uc.checkError = err
 		return err
 	}
-	uc.lastCheck = time.Now()
 	if CompareSemver(latestRemote, uc.latestVersion) == 1 {
 		uc.latestVersion = latestRemote
 	}

--- a/updates.go
+++ b/updates.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 A Bunch Tell LLC.
+ * Copyright © 2019-2020 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -63,9 +63,9 @@ func (uc updatesCache) LatestVersion() string {
 	return uc.latestVersion
 }
 
-// ReleaseURL returns the full URL to the blog.writefreely.org release notes
+// ReleaseNotesURL returns the full URL to the blog.writefreely.org release notes
 // for the latest version as stored in the cache.
-func (uc updatesCache) ReleaseURL() string {
+func (uc updatesCache) ReleaseNotesURL() string {
 	ver := strings.TrimPrefix(uc.latestVersion, "v")
 	ver = strings.TrimSuffix(ver, ".0")
 	// hack until go 1.12 in build/travis

--- a/updates.go
+++ b/updates.go
@@ -63,6 +63,10 @@ func (uc updatesCache) LatestVersion() string {
 	return uc.latestVersion
 }
 
+func (uc updatesCache) ReleaseURL() string {
+	return "https://writefreely.org/releases/" + uc.latestVersion
+}
+
 // ReleaseNotesURL returns the full URL to the blog.writefreely.org release notes
 // for the latest version as stored in the cache.
 func (uc updatesCache) ReleaseNotesURL() string {

--- a/updates.go
+++ b/updates.go
@@ -58,6 +58,12 @@ func (uc updatesCache) AreAvailable() bool {
 	return CompareSemver(uc.latestVersion, uc.currentVersion) == 1
 }
 
+// AreAvailableNoCheck returns if the latest release is newer than the current
+// running version.
+func (uc updatesCache) AreAvailableNoCheck() bool {
+	return CompareSemver(uc.latestVersion, uc.currentVersion) == 1
+}
+
 // LatestVersion returns the latest stored version available.
 func (uc updatesCache) LatestVersion() string {
 	return uc.latestVersion

--- a/updates.go
+++ b/updates.go
@@ -100,7 +100,7 @@ func newUpdatesCache(expiry time.Duration) *updatesCache {
 		frequency:      expiry,
 		currentVersion: "v" + softwareVer,
 	}
-	cache.CheckNow()
+	go cache.CheckNow()
 	return &cache
 }
 
@@ -117,6 +117,7 @@ func newVersionCheck() (string, error) {
 	if debugging {
 		log.Info("[update check] GET https://version.writefreely.org")
 	}
+	// TODO: return error if statusCode != OK
 	if err == nil && res.StatusCode == http.StatusOK {
 		defer res.Body.Close()
 

--- a/updates.go
+++ b/updates.go
@@ -70,7 +70,11 @@ func (uc updatesCache) ReleaseURL() string {
 // ReleaseNotesURL returns the full URL to the blog.writefreely.org release notes
 // for the latest version as stored in the cache.
 func (uc updatesCache) ReleaseNotesURL() string {
-	ver := strings.TrimPrefix(uc.latestVersion, "v")
+	return wfReleaseNotesURL(uc.latestVersion)
+}
+
+func wfReleaseNotesURL(v string) string {
+	ver := strings.TrimPrefix(v, "v")
 	ver = strings.TrimSuffix(ver, ".0")
 	// hack until go 1.12 in build/travis
 	seg := strings.Split(ver, ".")

--- a/updates.go
+++ b/updates.go
@@ -11,6 +11,7 @@
 package writefreely
 
 import (
+	"github.com/writeas/web-core/log"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -37,11 +38,15 @@ type updatesCache struct {
 // the cache last checked time. If the version postdates the current 'latest'
 // the version value is replaced.
 func (uc *updatesCache) CheckNow() error {
+	if debugging {
+		log.Info("[update check] Checking for update now.")
+	}
 	uc.mu.Lock()
 	defer uc.mu.Unlock()
 	uc.lastCheck = time.Now()
 	latestRemote, err := newVersionCheck()
 	if err != nil {
+		log.Error("[update check] Failed: %v", err)
 		uc.checkError = err
 		return err
 	}
@@ -109,6 +114,9 @@ func (app *App) InitUpdates() {
 
 func newVersionCheck() (string, error) {
 	res, err := http.Get("https://version.writefreely.org")
+	if debugging {
+		log.Info("[update check] GET https://version.writefreely.org")
+	}
 	if err == nil && res.StatusCode == http.StatusOK {
 		defer res.Body.Close()
 

--- a/updates_test.go
+++ b/updates_test.go
@@ -24,7 +24,7 @@ func TestUpdatesRoundTrip(t *testing.T) {
 	})
 
 	t.Run("Release URL", func(t *testing.T) {
-		url := cache.ReleaseURL()
+		url := cache.ReleaseNotesURL()
 
 		reg, err := regexp.Compile(`^https:\/\/blog.writefreely.org\/version(-\d+){1,}$`)
 		if err != nil {


### PR DESCRIPTION
Reworking the admin dashboard to be more organized, straightforward, and to optionally hide unnecessary information for non-technical admins in hosted environments like [Write.as for Teams](https://write.as/for/teams).

## Less-technical dashboard

This will close [T694](https://writefreely.org/tasks/694).

This hides the app Monitor tab on the dashboard if instance admin sets the following config value: `forest = true` (**note: experimental**).

This makes the App Configuration page more user-friendly by changing the user-facing language and adding descriptions to each item.

### New Admin Settings page

![screencapture-localhost-7879-admin-settings-2020-02-25-14_26_58](https://user-images.githubusercontent.com/1138779/75280739-082fe680-57dc-11ea-8c83-49a0ab918e94.png)

### New Dashboard

![screencapture-localhost-7879-admin-2020-02-25-14_27_21](https://user-images.githubusercontent.com/1138779/75280773-1847c600-57dc-11ea-876c-7774b0307b76.png)

### New Users page

![Screenshot from 2020-02-25 14-43-31](https://user-images.githubusercontent.com/1138779/75281457-572a4b80-57dd-11ea-9215-29f2240a5f8b.png)

### Update page

![screencapture-localhost-7879-admin-updates-2020-02-25-14_42_49](https://user-images.githubusercontent.com/1138779/75281477-627d7700-57dd-11ea-9c75-58b60faa1185.png)

Enabled with: `update_checks = true` (**note: experimental**).

## Automated "new version" checks

It also contains improvements to the automated update check system, both user-facing and on the backend (work started on #175 and [T572](https://writefreely.org/tasks/572)):

* Indicates a new update is available in the admin navigation bar
* Shows "last check" time in local timezone, like blog posts do
* Mentions update check error to admin when one occurs
* Mentions that update checks are disabled, when true and an admin navigates to the `/admin/updates` page
* Adds logging around update checks