### PR TITLE
Add 'X-Robots-Tag: noindex' header to invite URLs

### DIFF
--- a/invites.go
+++ b/invites.go
@@ -170,6 +170,9 @@ func handleViewInvite(app *App, w http.ResponseWriter, r *http.Request) error {
 		p.Error = "This invite link has expired."
 	}
 
+	// Tell search engines not to index invite links
+	w.Header().Set("X-Robots-Tag", "noindex")
+
 	// Get error messages
 	session, err := app.sessionStore.Get(r, cookieName)
 	if err != nil {


### PR DESCRIPTION
This instructs search engines to not index invite links.