### PR TITLE
add js, jsx and html aliases for highlightjs

### DIFF
--- a/templates/include/post-render.tmpl
+++ b/templates/include/post-render.tmpl
@@ -20,9 +20,12 @@
       "hh"         : "cpp",
       "hxx"        : "cpp",
       "cxx"        : "cpp",
-      "sh"         : "bash"
+      "sh"         : "bash",
+      "js"         : "javascript",
+      "jsx"        : "javascript",
+      "html"       : "xml"
     };
-    
+
     // Given a set of nodes, run highlighting on them
     function highlight(nodes) {
       for (i=0; i < nodes.length; i++) {


### PR DESCRIPTION
This adds aliases for highlightjs that allow to use the pretty common js, jsx abbreviations for javascript and html for xml.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
