### PR TITLE
Private instance cleanup

### DIFF
--- a/app.go
+++ b/app.go
@@ -221,6 +221,10 @@ func handleViewHome(app *App, w http.ResponseWriter, r *http.Request) error {
 			return handleViewPad(app, w, r)
 		}
 
+		if app.cfg.App.Private {
+			return viewLogin(app, w, r)
+		}
+
 		if land := app.cfg.App.LandingPath(); land != "/" {
 			return impart.HTTPError{http.StatusFound, land}
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -183,6 +183,16 @@ func (ac *AppCfg) LandingPath() string {
 	return ac.Landing
 }
 
+func (ac AppCfg) SignupPath() string {
+	if !ac.OpenRegistration {
+		return ""
+	}
+	if ac.Chorus || ac.Private || (ac.Landing != "" && ac.Landing != "/") {
+		return "/signup"
+	}
+	return "/"
+}
+
 // Load reads the given configuration file, then parses and returns it as a Config.
 func Load(fname string) (*Config, error) {
 	if fname == "" {

--- a/pages/login.tmpl
+++ b/pages/login.tmpl
@@ -65,7 +65,7 @@ hr.short {
 		<input type="submit" id="btn-login" value="Login" />
 	</form>
 
-	{{if and (not .SingleUser) .OpenRegistration}}<p style="text-align:center;font-size:0.9em;margin:3em auto;max-width:26em;">{{if .Message}}{{.Message}}{{else}}<em>No account yet?</em> <a href="/">Sign up</a> to start a blog.{{end}}</p>{{end}}
+	{{if and (not .SingleUser) .OpenRegistration}}<p style="text-align:center;font-size:0.9em;margin:3em auto;max-width:26em;">{{if .Message}}{{.Message}}{{else}}<em>No account yet?</em> <a href="{{.SignupPath}}">Sign up</a> to start a blog.{{end}}</p>{{end}}
 
 <script type="text/javascript">
 function disableSubmit() {

--- a/templates/base.tmpl
+++ b/templates/base.tmpl
@@ -48,7 +48,7 @@
 						{{ end }}
 					{{if and (and  .LocalTimeline .CanViewReader) (not .Chorus)}}<a href="/read"{{if eq .Path "/read"}} class="selected"{{end}}>Reader</a>{{end}}
 					{{if and (and (and  .Chorus .OpenRegistration) (not .Username)) (or (not .Private) (ne .Landing ""))}}<a href="/signup"{{if eq .Path "/signup"}} class="selected"{{end}}>Sign up</a>{{end}}
-					{{if not .Username}}<a href="/login"{{if eq .Path "/login"}} class="selected"{{end}}>Log in</a>{{else if .SimpleNav}}<a href="/me/logout">Log out</a>{{end}}
+					{{if and (not .Username) (not .Private)}}<a href="/login"{{if eq .Path "/login"}} class="selected"{{end}}>Log in</a>{{else if .SimpleNav}}<a href="/me/logout">Log out</a>{{end}}
 					{{ end }}
 				</nav>
 				{{if .Chorus}}{{if .Username}}<div class="right-side" style="font-size: 0.86em;">

--- a/templates/base.tmpl
+++ b/templates/base.tmpl
@@ -47,7 +47,7 @@
 					{{if not .DisableDrafts}}<a href="/me/posts/"{{if eq .Path "/me/posts/"}} class="selected"{{end}}>Drafts</a>{{end}}
 						{{ end }}
 					{{if and (and  .LocalTimeline .CanViewReader) (not .Chorus)}}<a href="/read"{{if eq .Path "/read"}} class="selected"{{end}}>Reader</a>{{end}}
-					{{if and (and (and  .Chorus .OpenRegistration) (not .Username)) (or (not .Private) (ne .Landing ""))}}<a href="/signup"{{if eq .Path "/signup"}} class="selected"{{end}}>Sign up</a>{{end}}
+					{{if eq .SignupPath "/signup"}}<a href="/signup"{{if eq .Path "/signup"}} class="selected"{{end}}>Sign up</a>{{end}}
 					{{if and (not .Username) (not .Private)}}<a href="/login"{{if eq .Path "/login"}} class="selected"{{end}}>Log in</a>{{else if .SimpleNav}}<a href="/me/logout">Log out</a>{{end}}
 					{{ end }}
 				</nav>

--- a/templates/include/footer.tmpl
+++ b/templates/include/footer.tmpl
@@ -6,7 +6,7 @@
 				<a class="home" href="/">{{.SiteName}}</a>
 				{{if not .SingleUser}}
 					<a href="/about">about</a>
-					{{if .LocalTimeline}}<a href="/read">reader</a>{{end}}
+					{{if and .LocalTimeline .CanViewReader}}<a href="/read">reader</a>{{end}}
 					{{if .Username}}<a href="https://writefreely.org/guide/{{.OfficialVersion}}" target="guide">writer's guide</a>{{end}}
 					<a href="/privacy">privacy</a>
 					<p style="font-size: 0.9em">powered by <a href="https://writefreely.org">writefreely</a></p>


### PR DESCRIPTION
This improves things a bit on private instances.

* Hide Reader link in footer when unauthenticated on private instances.
This isn't publicly visible, so as in the header, we now also hide this in the footer.
* Show **Log in** page as landing on private instances, instead of normal landing page.
Private instances are only meant for registered users, and are often closed or invite-only, making the current landing page kind of pointless (and potentially confusing). This remedies that by putting the login form first, while of course still linking to the signup page if an instance has open registrations.