### PR TITLE
Fix V4 + V5 SQLite migrations

### DIFF
--- a/db/create.go
+++ b/db/create.go
@@ -1,3 +1,13 @@
+/*
+ * Copyright © 2019-2020 A Bunch Tell LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
 package db
 
 import (

--- a/db/create.go
+++ b/db/create.go
@@ -177,7 +177,11 @@ func (c *Column) String() (string, error) {
 
 	if c.Default.Set {
 		str.WriteString(" DEFAULT ")
-		str.WriteString(c.Default.Value)
+		val := c.Default.Value
+		if val == "" {
+			val = "''"
+		}
+		str.WriteString(val)
 	}
 
 	if c.PrimaryKey {
@@ -250,4 +254,3 @@ func (b *CreateTableSqlBuilder) ToSQL() (string, error) {
 
 	return str.String(), nil
 }
-

--- a/db/create.go
+++ b/db/create.go
@@ -139,6 +139,15 @@ func (c *Column) SetDefault(value string) *Column {
 	return c
 }
 
+func (c *Column) SetDefaultCurrentTimestamp() *Column {
+	def := "NOW()"
+	if c.Dialect == DialectSQLite {
+		def = "CURRENT_TIMESTAMP"
+	}
+	c.Default = OptionalString{Set: true, Value: def}
+	return c
+}
+
 func (c *Column) SetType(t ColumnType) *Column {
 	c.Type = t
 	return c

--- a/migrations/v4.go
+++ b/migrations/v4.go
@@ -29,7 +29,7 @@ func oauth(db *datastore) error {
 			SetIfNotExists(true).
 			Column(dialect.Column("state", wf_db.ColumnTypeVarChar, wf_db.OptionalInt{Set: true, Value: 255})).
 			Column(dialect.Column("used", wf_db.ColumnTypeBool, wf_db.UnsetSize)).
-			Column(dialect.Column("created_at", wf_db.ColumnTypeDateTime, wf_db.UnsetSize).SetDefault("NOW()")).
+			Column(dialect.Column("created_at", wf_db.ColumnTypeDateTime, wf_db.UnsetSize).SetDefaultCurrentTimestamp()).
 			UniqueConstraint("state").
 			ToSQL()
 		if err != nil {

--- a/migrations/v4.go
+++ b/migrations/v4.go
@@ -25,7 +25,7 @@ func oauth(db *datastore) error {
 	return wf_db.RunTransactionWithOptions(context.Background(), db.DB, &sql.TxOptions{}, func(ctx context.Context, tx *sql.Tx) error {
 		createTableUsersOauth, err := dialect.
 			Table("oauth_users").
-			SetIfNotExists(true).
+			SetIfNotExists(false).
 			Column(dialect.Column("user_id", wf_db.ColumnTypeInteger, wf_db.UnsetSize)).
 			Column(dialect.Column("remote_user_id", wf_db.ColumnTypeInteger, wf_db.UnsetSize)).
 			ToSQL()
@@ -34,7 +34,7 @@ func oauth(db *datastore) error {
 		}
 		createTableOauthClientState, err := dialect.
 			Table("oauth_client_states").
-			SetIfNotExists(true).
+			SetIfNotExists(false).
 			Column(dialect.Column("state", wf_db.ColumnTypeVarChar, wf_db.OptionalInt{Set: true, Value: 255})).
 			Column(dialect.Column("used", wf_db.ColumnTypeBool, wf_db.UnsetSize)).
 			Column(dialect.Column("created_at", wf_db.ColumnTypeDateTime, wf_db.UnsetSize).SetDefaultCurrentTimestamp()).

--- a/migrations/v4.go
+++ b/migrations/v4.go
@@ -18,8 +18,6 @@ func oauth(db *datastore) error {
 			SetIfNotExists(true).
 			Column(dialect.Column("user_id", wf_db.ColumnTypeInteger, wf_db.UnsetSize)).
 			Column(dialect.Column("remote_user_id", wf_db.ColumnTypeInteger, wf_db.UnsetSize)).
-			UniqueConstraint("user_id").
-			UniqueConstraint("remote_user_id").
 			ToSQL()
 		if err != nil {
 			return err

--- a/migrations/v4.go
+++ b/migrations/v4.go
@@ -1,3 +1,13 @@
+/*
+ * Copyright © 2019-2020 A Bunch Tell LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
 package migrations
 
 import (

--- a/migrations/v5.go
+++ b/migrations/v5.go
@@ -49,8 +49,6 @@ func oauthSlack(db *datastore) error {
 						"access_token",
 						wf_db.ColumnTypeVarChar,
 						wf_db.OptionalInt{Set: true, Value: 512,})),
-			dialect.DropIndex("remote_user_id", "oauth_users"),
-			dialect.DropIndex("user_id", "oauth_users"),
 			dialect.CreateUniqueIndex("oauth_users", "oauth_users", "user_id", "provider", "client_id"),
 		}
 		for _, builder := range builders {

--- a/migrations/v5.go
+++ b/migrations/v5.go
@@ -20,36 +20,48 @@ func oauthSlack(db *datastore) error {
 					Column(
 						"provider",
 						wf_db.ColumnTypeVarChar,
-						wf_db.OptionalInt{Set: true, Value: 24,})).
+						wf_db.OptionalInt{Set: true, Value: 24})),
+			dialect.
+				AlterTable("oauth_client_states").
 				AddColumn(dialect.
 					Column(
 						"client_id",
 						wf_db.ColumnTypeVarChar,
-						wf_db.OptionalInt{Set: true, Value: 128,})),
+						wf_db.OptionalInt{Set: true, Value: 128})),
 			dialect.
 				AlterTable("oauth_users").
-				ChangeColumn("remote_user_id",
-					dialect.
-						Column(
-							"remote_user_id",
-							wf_db.ColumnTypeVarChar,
-							wf_db.OptionalInt{Set: true, Value: 128,})).
 				AddColumn(dialect.
 					Column(
 						"provider",
 						wf_db.ColumnTypeVarChar,
-						wf_db.OptionalInt{Set: true, Value: 24,})).
+						wf_db.OptionalInt{Set: true, Value: 24})),
+			dialect.
+				AlterTable("oauth_users").
 				AddColumn(dialect.
 					Column(
 						"client_id",
 						wf_db.ColumnTypeVarChar,
-						wf_db.OptionalInt{Set: true, Value: 128,})).
+						wf_db.OptionalInt{Set: true, Value: 128})),
+			dialect.
+				AlterTable("oauth_users").
 				AddColumn(dialect.
 					Column(
 						"access_token",
 						wf_db.ColumnTypeVarChar,
 						wf_db.OptionalInt{Set: true, Value: 512,})),
 			dialect.CreateUniqueIndex("oauth_users", "oauth_users", "user_id", "provider", "client_id"),
+		}
+
+		if dialect != wf_db.DialectSQLite {
+			// This updates the length of the `remote_user_id` column. It isn't needed for SQLite databases.
+			builders = append(builders, dialect.
+				AlterTable("oauth_users").
+				ChangeColumn("remote_user_id",
+					dialect.
+						Column(
+							"remote_user_id",
+							wf_db.ColumnTypeVarChar,
+							wf_db.OptionalInt{Set: true, Value: 128})))
 		}
 		for _, builder := range builders {
 			query, err := builder.ToSQL()

--- a/migrations/v5.go
+++ b/migrations/v5.go
@@ -49,7 +49,7 @@ func oauthSlack(db *datastore) error {
 						"access_token",
 						wf_db.ColumnTypeVarChar,
 						wf_db.OptionalInt{Set: true, Value: 512}).SetDefault("")),
-			dialect.CreateUniqueIndex("oauth_users", "oauth_users", "user_id", "provider", "client_id"),
+			dialect.CreateUniqueIndex("oauth_users_uk", "oauth_users", "user_id", "provider", "client_id"),
 		}
 
 		if dialect != wf_db.DialectSQLite {

--- a/migrations/v5.go
+++ b/migrations/v5.go
@@ -1,3 +1,13 @@
+/*
+ * Copyright © 2019-2020 A Bunch Tell LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
 package migrations
 
 import (

--- a/migrations/v5.go
+++ b/migrations/v5.go
@@ -20,35 +20,35 @@ func oauthSlack(db *datastore) error {
 					Column(
 						"provider",
 						wf_db.ColumnTypeVarChar,
-						wf_db.OptionalInt{Set: true, Value: 24})),
+						wf_db.OptionalInt{Set: true, Value: 24}).SetDefault("")),
 			dialect.
 				AlterTable("oauth_client_states").
 				AddColumn(dialect.
 					Column(
 						"client_id",
 						wf_db.ColumnTypeVarChar,
-						wf_db.OptionalInt{Set: true, Value: 128})),
+						wf_db.OptionalInt{Set: true, Value: 128}).SetDefault("")),
 			dialect.
 				AlterTable("oauth_users").
 				AddColumn(dialect.
 					Column(
 						"provider",
 						wf_db.ColumnTypeVarChar,
-						wf_db.OptionalInt{Set: true, Value: 24})),
+						wf_db.OptionalInt{Set: true, Value: 24}).SetDefault("")),
 			dialect.
 				AlterTable("oauth_users").
 				AddColumn(dialect.
 					Column(
 						"client_id",
 						wf_db.ColumnTypeVarChar,
-						wf_db.OptionalInt{Set: true, Value: 128})),
+						wf_db.OptionalInt{Set: true, Value: 128}).SetDefault("")),
 			dialect.
 				AlterTable("oauth_users").
 				AddColumn(dialect.
 					Column(
 						"access_token",
 						wf_db.ColumnTypeVarChar,
-						wf_db.OptionalInt{Set: true, Value: 512,})),
+						wf_db.OptionalInt{Set: true, Value: 512}).SetDefault("")),
 			dialect.CreateUniqueIndex("oauth_users", "oauth_users", "user_id", "provider", "client_id"),
 		}
 
@@ -63,6 +63,7 @@ func oauthSlack(db *datastore) error {
 							wf_db.ColumnTypeVarChar,
 							wf_db.OptionalInt{Set: true, Value: 128})))
 		}
+
 		for _, builder := range builders {
 			query, err := builder.ToSQL()
 			if err != nil {


### PR DESCRIPTION
This fixes the unreleased V4 and V5 database migrations so they work with instances backed by SQLite databases.