### PR TITLE
Login with generic oauth feature

### DIFF
--- a/account.go
+++ b/account.go
@@ -323,7 +323,7 @@ func viewLogin(app *App, w http.ResponseWriter, r *http.Request) error {
 		app.Config().WriteAsOauth.ClientID != "",
 		app.Config().GitlabOauth.ClientID != "",
         app.Config().GenericOauth.ClientID != "",
-        config.OrDefaultString(app.Config().GenericOauth.DisplayName, oAuthGenericDisplayName),
+        config.OrDefaultString(app.Config().GenericOauth.DisplayName, genericOauthDisplayName),
 		config.OrDefaultString(app.Config().GitlabOauth.DisplayName, gitlabDisplayName),
 	}
 

--- a/account.go
+++ b/account.go
@@ -66,7 +66,7 @@ func NewUserPage(app *App, r *http.Request, u *User, title string, flashes []str
 }
 
 func canUserInvite(cfg *config.Config, isAdmin bool) bool {
-	return cfg.App.UserInvites != "" &&
+      return cfg.App.UserInvites != "" &&
 		(isAdmin || cfg.App.UserInvites != "admin")
 }
 
@@ -303,14 +303,16 @@ func viewLogin(app *App, w http.ResponseWriter, r *http.Request) error {
 
 	p := &struct {
 		page.StaticPage
-		To                string
-		Message           template.HTML
-		Flashes           []template.HTML
-		LoginUsername     string
-		OauthSlack        bool
-		OauthWriteAs      bool
-		OauthGitlab       bool
-		GitlabDisplayName string
+		To                      string
+		Message                 template.HTML
+		Flashes                 []template.HTML
+		LoginUsername           string
+		OauthSlack              bool
+		OauthWriteAs            bool
+		OauthGitlab             bool
+        OauthGeneric            bool
+        OauthGenericDisplayName string
+		GitlabDisplayName       string
 	}{
 		pageForReq(app, r),
 		r.FormValue("to"),
@@ -320,6 +322,8 @@ func viewLogin(app *App, w http.ResponseWriter, r *http.Request) error {
 		app.Config().SlackOauth.ClientID != "",
 		app.Config().WriteAsOauth.ClientID != "",
 		app.Config().GitlabOauth.ClientID != "",
+        app.Config().GenericOauth.ClientID != "",
+        config.OrDefaultString(app.Config().GenericOauth.DisplayName, oAuthGenericDisplayName),
 		config.OrDefaultString(app.Config().GitlabOauth.DisplayName, gitlabDisplayName),
 	}
 

--- a/account.go
+++ b/account.go
@@ -66,7 +66,7 @@ func NewUserPage(app *App, r *http.Request, u *User, title string, flashes []str
 }
 
 func canUserInvite(cfg *config.Config, isAdmin bool) bool {
-      return cfg.App.UserInvites != "" &&
+	return cfg.App.UserInvites != "" &&
 		(isAdmin || cfg.App.UserInvites != "admin")
 }
 
@@ -310,8 +310,8 @@ func viewLogin(app *App, w http.ResponseWriter, r *http.Request) error {
 		OauthSlack              bool
 		OauthWriteAs            bool
 		OauthGitlab             bool
-        OauthGeneric            bool
-        OauthGenericDisplayName string
+		OauthGeneric            bool
+		OauthGenericDisplayName string
 		GitlabDisplayName       string
 	}{
 		pageForReq(app, r),
@@ -322,8 +322,8 @@ func viewLogin(app *App, w http.ResponseWriter, r *http.Request) error {
 		app.Config().SlackOauth.ClientID != "",
 		app.Config().WriteAsOauth.ClientID != "",
 		app.Config().GitlabOauth.ClientID != "",
-        app.Config().GenericOauth.ClientID != "",
-        config.OrDefaultString(app.Config().GenericOauth.DisplayName, genericOauthDisplayName),
+		app.Config().GenericOauth.ClientID != "",
+		config.OrDefaultString(app.Config().GenericOauth.DisplayName, genericOauthDisplayName),
 		config.OrDefaultString(app.Config().GitlabOauth.DisplayName, gitlabDisplayName),
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -86,6 +86,18 @@ type (
 		CallbackProxyAPI string `ini:"callback_proxy_api"`
 	}
 
+    GenericOauthCfg struct {
+        ClientID         string `ini:"client_id"`
+        ClientSecret     string `ini:"client_secret"`
+        Host             string `ini:"host"`
+        DisplayName      string `ini:"display_name"`
+        CallbackProxy    string `ini:"callback_proxy"`
+        CallbackProxyAPI string `ini:"callback_proxy_api"`
+        TokenEndpoint    string `ini:"token_endpoint"`
+        InspectEndpoint  string `ini:"inspect_endpoint"`
+        AuthEndpoint     string `ini:"auth_endpoint"`
+    }
+
 	// AppCfg holds values that affect how the application functions
 	AppCfg struct {
 		SiteName string `ini:"site_name"`
@@ -138,6 +150,7 @@ type (
 		SlackOauth   SlackOauthCfg   `ini:"oauth.slack"`
 		WriteAsOauth WriteAsOauthCfg `ini:"oauth.writeas"`
 		GitlabOauth  GitlabOauthCfg  `ini:"oauth.gitlab"`
+        GenericOauth GenericOauthCfg `ini:"oauth.generic"`
 	}
 )
 

--- a/oauth.go
+++ b/oauth.go
@@ -222,7 +222,6 @@ func configureGenericOauth(parentHandler *Handler, r *mux.Router, app *App) {
 			callbackLocation = app.Config().GenericOauth.CallbackProxy
 		}
 
-		address := app.Config().GenericOauth.Host
 		oauthClient := genericOauthClient{
 			ClientID:         app.Config().GenericOauth.ClientID,
 			ClientSecret:     app.Config().GenericOauth.ClientSecret,

--- a/oauth.go
+++ b/oauth.go
@@ -209,31 +209,31 @@ func configureGitlabOauth(parentHandler *Handler, r *mux.Router, app *App) {
 }
 
 func configureGenericOauth(parentHandler *Handler, r *mux.Router, app *App) {
-    if app.Config().GenericOauth.ClientID != "" {
-        callbackLocation := app.Config().App.Host + "/oauth/callback/generic"
+	if app.Config().GenericOauth.ClientID != "" {
+		callbackLocation := app.Config().App.Host + "/oauth/callback/generic"
 
-        var callbackProxy *callbackProxyClient = nil
-        if app.Config().GenericOauth.CallbackProxy != "" {
-            callbackProxy = &callbackProxyClient {
-                server:           app.Config().GenericOauth.CallbackProxyAPI,
-                callbackLocation: app.Config().App.Host + "/oauth/callback/generic",
-                httpClient:       config.DefaultHTTPClient(),
-            }
-            callbackLocation = app.Config().GenericOauth.CallbackProxy
-        }
+		var callbackProxy *callbackProxyClient = nil
+		if app.Config().GenericOauth.CallbackProxy != "" {
+			callbackProxy = &callbackProxyClient{
+				server:           app.Config().GenericOauth.CallbackProxyAPI,
+				callbackLocation: app.Config().App.Host + "/oauth/callback/generic",
+				httpClient:       config.DefaultHTTPClient(),
+			}
+			callbackLocation = app.Config().GenericOauth.CallbackProxy
+		}
 
-        address := app.Config().GenericOauth.Host
-        oauthClient := genericOauthClient{
-            ClientID:         app.Config().GenericOauth.ClientID,
-            ClientSecret:     app.Config().GenericOauth.ClientSecret,
-            ExchangeLocation: app.Config().GenericOauth.TokenEndpoint,
-            InspectLocation:  app.Config().GenericOauth.InspectEndpoint,
-            AuthLocation:     app.Config().GenericOauth.AuthEndpoint,
-            HttpClient:       config.DefaultHTTPClient(),
-            CallbackLocation: callbackLocation,
-        }
-        configureOauthRoutes(parentHandler, r, app, oauthClient, callbackProxy)
-    }
+		address := app.Config().GenericOauth.Host
+		oauthClient := genericOauthClient{
+			ClientID:         app.Config().GenericOauth.ClientID,
+			ClientSecret:     app.Config().GenericOauth.ClientSecret,
+			ExchangeLocation: app.Config().GenericOauth.TokenEndpoint,
+			InspectLocation:  app.Config().GenericOauth.InspectEndpoint,
+			AuthLocation:     app.Config().GenericOauth.AuthEndpoint,
+			HttpClient:       config.DefaultHTTPClient(),
+			CallbackLocation: callbackLocation,
+		}
+		configureOauthRoutes(parentHandler, r, app, oauthClient, callbackProxy)
+	}
 }
 
 func configureOauthRoutes(parentHandler *Handler, r *mux.Router, app *App, oauthClient oauthClient, callbackProxy *callbackProxyClient) {

--- a/oauth.go
+++ b/oauth.go
@@ -208,6 +208,34 @@ func configureGitlabOauth(parentHandler *Handler, r *mux.Router, app *App) {
 	}
 }
 
+func configureGenericOauth(parentHandler *Handler, r *mux.Router, app *App) {
+    if app.Config().GenericOauth.ClientID != "" {
+        callbackLocation := app.Config().App.Host + "/oauth/callback/generic"
+
+        var callbackProxy *callbackProxyClient = nil
+        if app.Config().GenericOauth.CallbackProxy != "" {
+            callbackProxy = &callbackProxyClient {
+                server:           app.Config().GenericOauth.CallbackProxyAPI,
+                callbackLocation: app.Config().App.Host + "/oauth/callback/generic",
+                httpClient:       config.DefaultHTTPClient(),
+            }
+            callbackLocation = app.Config().GenericOauth.CallbackProxy
+        }
+
+        address := app.Config().GenericOauth.Host
+        oauthClient := genericOauthClient{
+            ClientID:         app.Config().GenericOauth.ClientID,
+            ClientSecret:     app.Config().GenericOauth.ClientSecret,
+            ExchangeLocation: app.Config().GenericOauth.TokenEndpoint,
+            InspectLocation:  app.Config().GenericOauth.InspectEndpoint,
+            AuthLocation:     app.Config().GenericOauth.AuthEndpoint,
+            HttpClient:       config.DefaultHTTPClient(),
+            CallbackLocation: callbackLocation,
+        }
+        configureOauthRoutes(parentHandler, r, app, oauthClient, callbackProxy)
+    }
+}
+
 func configureOauthRoutes(parentHandler *Handler, r *mux.Router, app *App, oauthClient oauthClient, callbackProxy *callbackProxyClient) {
 	handler := &oauthHandler{
 		Config:        app.Config(),

--- a/oauth.go
+++ b/oauth.go
@@ -225,9 +225,9 @@ func configureGenericOauth(parentHandler *Handler, r *mux.Router, app *App) {
 		oauthClient := genericOauthClient{
 			ClientID:         app.Config().GenericOauth.ClientID,
 			ClientSecret:     app.Config().GenericOauth.ClientSecret,
-			ExchangeLocation: app.Config().GenericOauth.TokenEndpoint,
-			InspectLocation:  app.Config().GenericOauth.InspectEndpoint,
-			AuthLocation:     app.Config().GenericOauth.AuthEndpoint,
+			ExchangeLocation: app.Config().GenericOauth.Host + app.Config().GenericOauth.TokenEndpoint,
+			InspectLocation:  app.Config().GenericOauth.Host + app.Config().GenericOauth.InspectEndpoint,
+			AuthLocation:     app.Config().GenericOauth.Host + app.Config().GenericOauth.AuthEndpoint,
 			HttpClient:       config.DefaultHTTPClient(),
 			CallbackLocation: callbackLocation,
 		}

--- a/oauth_generic.go
+++ b/oauth_generic.go
@@ -21,7 +21,7 @@ type genericOauthClient struct {
 var _ oauthClient = genericOauthClient{}
 
 const (
-	genericOauthDisplayName = "oAuth"
+	genericOauthDisplayName = "OAuth"
 )
 
 func (c genericOauthClient) GetProvider() string {

--- a/oauth_generic.go
+++ b/oauth_generic.go
@@ -21,7 +21,7 @@ type genericOauthClient struct {
 var _ oauthClient = genericOauthClient{}
 
 const (
-    genericOauthDisplayName = "oAuth"
+	genericOauthDisplayName = "oAuth"
 )
 
 func (c genericOauthClient) GetProvider() string {

--- a/oauth_generic.go
+++ b/oauth_generic.go
@@ -1,0 +1,114 @@
+package writefreely
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type genericOauthClient struct {
+	ClientID         string
+	ClientSecret     string
+	AuthLocation     string
+	ExchangeLocation string
+	InspectLocation  string
+	CallbackLocation string
+	HttpClient       HttpClient
+}
+
+var _ oauthClient = genericOauthClient{}
+
+const (
+    genericOauthDisplayName = "oAuth"
+)
+
+func (c genericOauthClient) GetProvider() string {
+	return "generic"
+}
+
+func (c genericOauthClient) GetClientID() string {
+	return c.ClientID
+}
+
+func (c genericOauthClient) GetCallbackLocation() string {
+	return c.CallbackLocation
+}
+
+func (c genericOauthClient) buildLoginURL(state string) (string, error) {
+	u, err := url.Parse(c.AuthLocation)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set("client_id", c.ClientID)
+	q.Set("redirect_uri", c.CallbackLocation)
+	q.Set("response_type", "code")
+	q.Set("state", state)
+	q.Set("scope", "read_user")
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func (c genericOauthClient) exchangeOauthCode(ctx context.Context, code string) (*TokenResponse, error) {
+	form := url.Values{}
+	form.Add("grant_type", "authorization_code")
+	form.Add("redirect_uri", c.CallbackLocation)
+	form.Add("scope", "read_user")
+	form.Add("code", code)
+	req, err := http.NewRequest("POST", c.ExchangeLocation, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.WithContext(ctx)
+	req.Header.Set("User-Agent", "writefreely")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(c.ClientID, c.ClientSecret)
+
+	resp, err := c.HttpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("unable to exchange code for access token")
+	}
+
+	var tokenResponse TokenResponse
+	if err := limitedJsonUnmarshal(resp.Body, tokenRequestMaxLen, &tokenResponse); err != nil {
+		return nil, err
+	}
+	if tokenResponse.Error != "" {
+		return nil, errors.New(tokenResponse.Error)
+	}
+	return &tokenResponse, nil
+}
+
+func (c genericOauthClient) inspectOauthAccessToken(ctx context.Context, accessToken string) (*InspectResponse, error) {
+	req, err := http.NewRequest("GET", c.InspectLocation, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.WithContext(ctx)
+	req.Header.Set("User-Agent", "writefreely")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := c.HttpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("unable to inspect access token")
+	}
+
+	var inspectResponse InspectResponse
+	if err := limitedJsonUnmarshal(resp.Body, infoRequestMaxLen, &inspectResponse); err != nil {
+		return nil, err
+	}
+	if inspectResponse.Error != "" {
+		return nil, errors.New(inspectResponse.Error)
+	}
+	return &inspectResponse, nil
+}

--- a/pages/login.tmpl
+++ b/pages/login.tmpl
@@ -36,6 +36,10 @@ hr.short {
 	box-sizing: border-box;
 	font-size: 17px;
 }
+#generic-oauth-login {
+    box-sizing: border-box;
+    font-size: 17px;
+}
 </style>
 {{end}}
 {{define "content"}}
@@ -46,7 +50,7 @@ hr.short {
 		{{range .Flashes}}<li class="urgent">{{.}}</li>{{end}}
 	</ul>{{end}}
 
-	{{ if or .OauthSlack .OauthWriteAs .OauthGitlab }}
+	{{ if or .OauthSlack .OauthWriteAs .OauthGitlab .OauthGeneric }}
 		<div class="row content-container signinbtns">
 		{{ if .OauthSlack }}
 			<a class="loginbtn" href="/oauth/slack"><img alt="Sign in with Slack" height="40" width="172" src="/img/sign_in_with_slack.png" srcset="/img/sign_in_with_slack.png 1x, /img/sign_in_with_slack@2x.png 2x" /></a>
@@ -57,6 +61,9 @@ hr.short {
 		{{ if .OauthGitlab }}
 			<a class="btn cta loginbtn" id="gitlab-login" href="/oauth/gitlab">Sign in with <strong>{{.GitlabDisplayName}}</strong></a>
 		{{ end }}
+        {{ if .OauthGeneric }}
+            <a class="btn cta loginbtn" id="generic-oauth-login" href="/oauth/generic">Sign in with <strong>{{ .GenericOauthDisplayName }}</strong></a>
+        {{ end }}
 		</div>
 
 		<div class="or">

--- a/pages/login.tmpl
+++ b/pages/login.tmpl
@@ -62,7 +62,7 @@ hr.short {
 			<a class="btn cta loginbtn" id="gitlab-login" href="/oauth/gitlab">Sign in with <strong>{{.GitlabDisplayName}}</strong></a>
 		{{ end }}
         {{ if .OauthGeneric }}
-            <a class="btn cta loginbtn" id="generic-oauth-login" href="/oauth/generic">Sign in with <strong>{{ .GenericOauthDisplayName }}</strong></a>
+            <a class="btn cta loginbtn" id="generic-oauth-login" href="/oauth/generic">Sign in with <strong>{{ .OauthGenericDisplayName }}</strong></a>
         {{ end }}
 		</div>
 

--- a/routes.go
+++ b/routes.go
@@ -76,7 +76,7 @@ func InitRoutes(apper Apper, r *mux.Router) *mux.Router {
 	configureSlackOauth(handler, write, apper.App())
 	configureWriteAsOauth(handler, write, apper.App())
 	configureGitlabOauth(handler, write, apper.App())
-    configureGenericOauth(handler, write, apper.App())
+	configureGenericOauth(handler, write, apper.App())
 
 	// Set up dyamic page handlers
 	// Handle auth

--- a/routes.go
+++ b/routes.go
@@ -76,6 +76,7 @@ func InitRoutes(apper Apper, r *mux.Router) *mux.Router {
 	configureSlackOauth(handler, write, apper.App())
 	configureWriteAsOauth(handler, write, apper.App())
 	configureGitlabOauth(handler, write, apper.App())
+    configureGenericOauth(handler, write, apper.App())
 
 	// Set up dyamic page handlers
 	// Handle auth


### PR DESCRIPTION
This aims to add a configurable, generic OAuth client module, so that it can be used with things like Keycloak etc, without needing a separate OAuth client configuration for every provider.

It adds the following ini settings under `oauth.generic`:
- `client_id`, `client_secret`, `CallbackProxy`, `CallbackProxyAPI` as usual
- `host`: The hostname/base URL for the oauth server
- `display_name`: The display name (defaults to "OAuth")
- `token_endpoint`, `inspect_endpoint`, `auth_endpoint` which will all be different depending on the oauth implementation.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
