### PR TITLE
core.less: Use a bigger font size for h2

### DIFF
--- a/less/core.less
+++ b/less/core.less
@@ -81,7 +81,7 @@ body {
 				font-size: 1.5em;
 			}
 			h2 {
-				font-size: 1.17em;
+				font-size: 1.2em;
 			}
 		}
 


### PR DESCRIPTION
The font-size for h2 was set to be 1.17em, which is also the font size defined for h3 by user agent stylesheet. This lead to both h2 and h3 being rendered in same size. Use 1.2em for h2.

Closes: #217

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
