### PR TITLE
preload fonts.css in base.tmpl

### DIFF
--- a/templates/base.tmpl
+++ b/templates/base.tmpl
@@ -3,6 +3,9 @@
 	<head>
 		{{ template "head" . }}
 		<link rel="stylesheet" type="text/css" href="{{.Host}}/css/{{.Theme}}.css" />
+	{{ if .WebFonts}}
+		<link href="{{.Host}}/css/fonts.css" rel="preload" type="text/css" />
+	{{ end }}
 		<link rel="shortcut icon" href="{{.Host}}/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 


### PR DESCRIPTION
Hi, this is an "explorational" pull request.
PageSpeed Insights tells me I could gain about 500ms on my blog, if I preloaded fonts.css.
Would you be open to preloading fonts like this?
From a read of the templates and the generated HTML, it seems you always end up at the resource at `{{.Host}}/css/fonts.css`. The JS bit in the bottom just controls when to enable it. Preloading with a `<link>` element shouldn't change that behavior.

Let me know if that looks acceptable, I'm happy to throw additional commits in this pull request branch for the other template files.

[Describe the pull request here...]

---

- [ ] I have signed the [CLA](https://phabricator.write.as/L1)
