### PR TITLE
Add CORS header ('Access-Control-Allow-Origin') to public APIs

### DIFF
--- a/handle.go
+++ b/handle.go
@@ -599,6 +599,9 @@ func (h *Handler) AllReader(f handlerFunc) http.HandlerFunc {
 				log.Info(h.app.ReqLog(r, status, time.Since(start)))
 			}()
 
+			// Allow any origin, as public endpoints are handled in here
+			w.Header().Set("Access-Control-Allow-Origin", "*");
+
 			if h.app.App().cfg.App.Private {
 				// This instance is private, so ensure it's being accessed by a valid user
 				// Check if authenticated with an access token


### PR DESCRIPTION
This permits external websites to query WriteFreely instances for:
 * Collections
 * Public posts in collections
 * Specific public posts.

Without these changes, websites attempting to use the public API to query collections (such as my site: [moor3.xyz](moor3.xyz), [source](https://gitlab.com/Dar13/moor3-website)) will receive CORS errors. @cjeller1592 helped me in the past with a CORS proxy ([discussion](https://discuss.write.as/t/javascript-cors-errors/810?u=dar13)), but it's time to fix it at the source.

I consider this PR to be more like an RFC, I'm fully open to guidance/critique on how to make these changes acceptable.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
