### PR TITLE
Support Web Monetization

### DIFF
--- a/account.go
+++ b/account.go
@@ -839,6 +839,9 @@ func viewEditCollection(app *App, u *User, w http.ResponseWriter, r *http.Reques
 		return ErrCollectionNotFound
 	}
 
+	// Add collection properties
+	c.Monetization = app.db.GetCollectionAttribute(c.ID, "monetization_pointer")
+
 	silenced, err := app.db.IsUserSilenced(u.ID)
 	if err != nil {
 		log.Error("view edit collection %v", err)

--- a/account.go
+++ b/account.go
@@ -840,7 +840,7 @@ func viewEditCollection(app *App, u *User, w http.ResponseWriter, r *http.Reques
 	}
 
 	// Add collection properties
-	c.Monetization = app.db.GetCollectionAttribute(c.ID, "monetization_pointer")
+	c.MonetizationPointer = app.db.GetCollectionAttribute(c.ID, "monetization_pointer")
 
 	silenced, err := app.db.IsUserSilenced(u.ID)
 	if err != nil {

--- a/admin.go
+++ b/admin.go
@@ -529,6 +529,7 @@ func handleAdminUpdateConfig(apper Apper, u *User, w http.ResponseWriter, r *htt
 	}
 	apper.App().cfg.App.Federation = r.FormValue("federation") == "on"
 	apper.App().cfg.App.PublicStats = r.FormValue("public_stats") == "on"
+	apper.App().cfg.App.Monetization = r.FormValue("monetization") == "on"
 	apper.App().cfg.App.Private = r.FormValue("private") == "on"
 	apper.App().cfg.App.LocalTimeline = r.FormValue("local_timeline") == "on"
 	if apper.App().cfg.App.LocalTimeline && apper.App().timeline == nil {

--- a/collections.go
+++ b/collections.go
@@ -552,6 +552,7 @@ type CollectionPage struct {
 	IsOwner        bool
 	CanPin         bool
 	Username       string
+	Monetization   string
 	Collections    *[]Collection
 	PinnedPosts    *[]PublicPost
 	IsAdmin        bool
@@ -829,6 +830,7 @@ func handleViewCollection(app *App, w http.ResponseWriter, r *http.Request) erro
 	// Add more data
 	// TODO: fix this mess of collections inside collections
 	displayPage.PinnedPosts, _ = app.db.GetPinnedPosts(coll.CollectionObj, isOwner)
+	displayPage.Monetization = app.db.GetCollectionAttribute(coll.ID, "monetization_pointer")
 
 	collTmpl := "collection"
 	if app.cfg.App.Chorus {
@@ -947,6 +949,7 @@ func handleViewCollectionTag(app *App, w http.ResponseWriter, r *http.Request) e
 	// Add more data
 	// TODO: fix this mess of collections inside collections
 	displayPage.PinnedPosts, _ = app.db.GetPinnedPosts(coll.CollectionObj, isOwner)
+	displayPage.Monetization = app.db.GetCollectionAttribute(coll.ID, "monetization_pointer")
 
 	err = templates["collection-tags"].ExecuteTemplate(w, "collection-tags", displayPage)
 	if err != nil {

--- a/collections.go
+++ b/collections.go
@@ -56,7 +56,7 @@ type (
 		PublicOwner bool           `datastore:"public_owner" json:"-"`
 		URL         string         `json:"url,omitempty"`
 
-		Monetization string `json:"monetization_pointer,omitempty"`
+		MonetizationPointer string `json:"monetization_pointer,omitempty"`
 
 		db       *datastore
 		hostName string

--- a/collections.go
+++ b/collections.go
@@ -56,6 +56,8 @@ type (
 		PublicOwner bool           `datastore:"public_owner" json:"-"`
 		URL         string         `json:"url,omitempty"`
 
+		Monetization string `json:"monetization_pointer,omitempty"`
+
 		db       *datastore
 		hostName string
 	}
@@ -87,14 +89,15 @@ type (
 		Handle    string `schema:"handle" json:"handle"`
 
 		// Actual collection values updated in the DB
-		Alias       *string         `schema:"alias" json:"alias"`
-		Title       *string         `schema:"title" json:"title"`
-		Description *string         `schema:"description" json:"description"`
-		StyleSheet  *sql.NullString `schema:"style_sheet" json:"style_sheet"`
-		Script      *sql.NullString `schema:"script" json:"script"`
-		Signature   *sql.NullString `schema:"signature" json:"signature"`
-		Visibility  *int            `schema:"visibility" json:"public"`
-		Format      *sql.NullString `schema:"format" json:"format"`
+		Alias        *string         `schema:"alias" json:"alias"`
+		Title        *string         `schema:"title" json:"title"`
+		Description  *string         `schema:"description" json:"description"`
+		StyleSheet   *sql.NullString `schema:"style_sheet" json:"style_sheet"`
+		Script       *sql.NullString `schema:"script" json:"script"`
+		Signature    *sql.NullString `schema:"signature" json:"signature"`
+		Monetization *string         `schema:"monetization_pointer" json:"monetization_pointer"`
+		Visibility   *int            `schema:"visibility" json:"public"`
+		Format       *sql.NullString `schema:"format" json:"format"`
 	}
 	CollectionFormat struct {
 		Format string

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 A Bunch Tell LLC.
+ * Copyright © 2018-2020 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -136,9 +136,11 @@ type (
 		MinUsernameLen   int  `ini:"min_username_len"`
 		MaxBlogs         int  `ini:"max_blogs"`
 
+		// Options for public instances
 		// Federation
-		Federation  bool `ini:"federation"`
-		PublicStats bool `ini:"public_stats"`
+		Federation   bool `ini:"federation"`
+		PublicStats  bool `ini:"public_stats"`
+		Monetization bool `ini:"monetization"`
 
 		// Access
 		Private bool `ini:"private"`

--- a/database.go
+++ b/database.go
@@ -905,6 +905,15 @@ func (db *datastore) UpdateCollection(c *SubmittedCollection, alias string) erro
 		}
 	}
 
+	// Update Monetization value
+	if c.Monetization != nil {
+		_, err = db.Exec("INSERT INTO collectionattributes (collection_id, attribute, value) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE value = ?", collID, "monetization_pointer", *c.Monetization, *c.Monetization)
+		if err != nil {
+			log.Error("Unable to insert monetization_pointer value: %v", err)
+			return err
+		}
+	}
+
 	// Update rest of the collection data
 	res, err = db.Exec("UPDATE collections SET "+q.Updates+" WHERE "+q.Conditions, q.Params...)
 	if err != nil {
@@ -2649,11 +2658,11 @@ func (db *datastore) GetIDForRemoteUser(ctx context.Context, remoteUserID, provi
 }
 
 type oauthAccountInfo struct {
-	Provider         string
-	ClientID         string
-	RemoteUserID     string
-	DisplayName      string
-	AllowDisconnect  bool
+	Provider        string
+	ClientID        string
+	RemoteUserID    string
+	DisplayName     string
+	AllowDisconnect bool
 }
 
 func (db *datastore) GetOauthAccounts(ctx context.Context, userID int64) ([]oauthAccountInfo, error) {

--- a/database.go
+++ b/database.go
@@ -2162,6 +2162,28 @@ func (db *datastore) CollectionHasAttribute(id int64, attr string) bool {
 	return true
 }
 
+func (db *datastore) GetCollectionAttribute(id int64, attr string) string {
+	var v string
+	err := db.QueryRow("SELECT value FROM collectionattributes WHERE collection_id = ? AND attribute = ?", id, attr).Scan(&v)
+	switch {
+	case err == sql.ErrNoRows:
+		return ""
+	case err != nil:
+		log.Error("Couldn't SELECT value in getCollectionAttribute for attribute '%s': %v", attr, err)
+		return ""
+	}
+	return v
+}
+
+func (db *datastore) SetCollectionAttribute(id int64, attr, v string) error {
+	_, err := db.Exec("INSERT INTO collectionattributes (collection_id, attribute, value) VALUES (?, ?, ?)", id, attr, v)
+	if err != nil {
+		log.Error("Unable to INSERT into collectionattributes: %v", err)
+		return err
+	}
+	return nil
+}
+
 // DeleteAccount will delete the entire account for userID
 func (db *datastore) DeleteAccount(userID int64) error {
 	// Get all collections

--- a/posts.go
+++ b/posts.go
@@ -1476,6 +1476,7 @@ Are you sure it was ever here?`,
 			IsOwner        bool
 			IsPinned       bool
 			IsCustomDomain bool
+			Monetization   string
 			PinnedPosts    *[]PublicPost
 			IsFound        bool
 			IsAdmin        bool
@@ -1493,6 +1494,7 @@ Are you sure it was ever here?`,
 		tp.CanInvite = canUserInvite(app.cfg, tp.IsAdmin)
 		tp.PinnedPosts, _ = app.db.GetPinnedPosts(coll, p.IsOwner)
 		tp.IsPinned = len(*tp.PinnedPosts) > 0 && PostsContains(tp.PinnedPosts, p)
+		tp.Monetization = app.db.GetCollectionAttribute(coll.ID, "monetization_pointer")
 
 		if !postFound {
 			w.WriteHeader(http.StatusNotFound)

--- a/templates/chorus-collection-post.tmpl
+++ b/templates/chorus-collection-post.tmpl
@@ -29,6 +29,7 @@
 		<meta property="og:updated_time" content="{{.Created8601}}" />
 		{{range .Images}}<meta property="og:image" content="{{.}}" />{{else}}<meta property="og:image" content="{{.Collection.AvatarURL}}">{{end}}
 		<meta property="article:published_time" content="{{.Created8601}}">
+		{{template "collection-meta" .}}
 		{{if .Collection.StyleSheet}}<style type="text/css">{{.Collection.StyleSheetDisplay}}</style>{{end}}
 	<style type="text/css">
 body footer {

--- a/templates/chorus-collection.tmpl
+++ b/templates/chorus-collection.tmpl
@@ -27,6 +27,7 @@
 		<meta property="og:url" content="{{.CanonicalURL}}" />
 		<meta property="og:description" content="{{.Description}}" />
 		<meta property="og:image" content="{{.AvatarURL}}">
+		{{template "collection-meta" .}}
 		{{if .StyleSheet}}<style type="text/css">{{.StyleSheetDisplay}}</style>{{end}}
 	<style type="text/css">
 body#collection header {

--- a/templates/collection-post.tmpl
+++ b/templates/collection-post.tmpl
@@ -31,6 +31,7 @@
 		{{range .Images}}<meta property="og:image" content="{{.}}" />{{else}}<meta property="og:image" content="{{.Collection.AvatarURL}}">{{end}}
 		<meta property="article:published_time" content="{{.Created8601}}">
 		{{ end }}
+		{{template "collection-meta" .}}
 		{{if .Collection.StyleSheet}}<style type="text/css">{{.Collection.StyleSheetDisplay}}</style>{{end}}
 
 		{{if .Collection.RenderMathJax}}

--- a/templates/collection-tags.tmpl
+++ b/templates/collection-tags.tmpl
@@ -29,6 +29,7 @@
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="{{.CanonicalURL}}tag:{{.Tag}}" />
 		<meta property="og:image" content="{{.Collection.AvatarURL}}">
+		{{template "collection-meta" .}}
 		{{if .Collection.StyleSheet}}<style type="text/css">{{.Collection.StyleSheetDisplay}}</style>{{end}}
 
 		{{if .Collection.RenderMathJax}}

--- a/templates/collection.tmpl
+++ b/templates/collection.tmpl
@@ -27,6 +27,7 @@
 		<meta property="og:url" content="{{.CanonicalURL}}" />
 		<meta property="og:description" content="{{.Description}}" />
 		<meta property="og:image" content="{{.AvatarURL}}">
+		{{template "collection-meta" .}}
 		{{if .StyleSheet}}<style type="text/css">{{.StyleSheetDisplay}}</style>{{end}}
 
 		{{if .RenderMathJax}}

--- a/templates/include/post-render.tmpl
+++ b/templates/include/post-render.tmpl
@@ -1,4 +1,10 @@
 <!-- Miscelaneous render related template parts we use multiple times -->
+{{define "collection-meta"}}
+	{{if .Monetization -}}
+		<meta name="monetization" content="{{.Monetization}}" />
+	{{- end}}
+{{end}}
+
 {{define "highlighting"}}
 <script>
   // TODO: this feels more like a mutation observer

--- a/templates/user/admin/app-settings.tmpl
+++ b/templates/user/admin/app-settings.tmpl
@@ -137,6 +137,13 @@ select {
 			<div><input type="checkbox" name="public_stats" id="public_stats" {{if .Config.PublicStats}}checked="checked"{{end}} /></div>
 		</div>
 		<div class="features row">
+			<div><label for="monetization">
+					Monetization
+					<p>Enable blogs on this site to receive micro&shy;pay&shy;ments from readers via <a target="wm" href="https://webmonetization.org/">Web Monetization</a>.</p>
+				</label></div>
+			<div><input type="checkbox" name="monetization" id="monetization" {{if .Config.Monetization}}checked="checked"{{end}} /></div>
+		</div>
+		<div class="features row">
 			<div><label for="min_username_len">
 					Minimum Username Length
 					<p>The minimum number of characters allowed in a username. (Recommended: 2 or more.)</p>

--- a/templates/user/collection.tmpl
+++ b/templates/user/collection.tmpl
@@ -146,6 +146,14 @@ textarea.section.norm {
 		</div>
 	</div>
 
+	<div class="option">
+		<h2>Web Monetization</h2>
+		<div class="section">
+			<p class="explain">Web Monetization enables you to receive micropayments from readers that have a <a href="https://coil.com">Coil membership</a>. Add your payment pointer to enable Web Monetization on your blog.</p>
+			<input type="text" name="monetization_pointer" style="width:100%" value="{{.Monetization}}" placeholder="$wallet.example.com/alice" />
+		</div>
+	</div>
+
 	<div class="option" style="text-align: center; margin-top: 4em;">
 		<input type="submit" id="save-changes" value="Save changes" />
 		<p><a href="{{if .SingleUser}}/{{else}}/{{.Alias}}/{{end}}">View Blog</a></p>

--- a/templates/user/collection.tmpl
+++ b/templates/user/collection.tmpl
@@ -146,13 +146,15 @@ textarea.section.norm {
 		</div>
 	</div>
 
+	{{if .Monetization}}
 	<div class="option">
 		<h2>Web Monetization</h2>
 		<div class="section">
 			<p class="explain">Web Monetization enables you to receive micropayments from readers that have a <a href="https://coil.com">Coil membership</a>. Add your payment pointer to enable Web Monetization on your blog.</p>
-			<input type="text" name="monetization_pointer" style="width:100%" value="{{.Monetization}}" placeholder="$wallet.example.com/alice" />
+			<input type="text" name="monetization_pointer" style="width:100%" value="{{.MonetizationPointer}}" placeholder="$wallet.example.com/alice" />
 		</div>
 	</div>
+	{{end}}
 
 	<div class="option" style="text-align: center; margin-top: 4em;">
 		<input type="submit" id="save-changes" value="Save changes" />


### PR DESCRIPTION
This PR adds support for [Web Monetization](https://webmonetization.org/).

This feature is optional -- admins can enable it by setting `monetization = true` in the `[app]` section of their config -- or changing the setting in their admin panel.

When enabled, users will find a new "Web Monetization" field on the Customize page, with a little information on how it works.

This closes [T773](https://phabricator.write.as/T773).

- [x] Support `monetization` meta tag
- [x] Enable end users to add a monetization pointer
- [x] Enable end users to update their monetization pointer

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
