### PR TITLE
Truncate post lede at question mark

### DIFF
--- a/oauth_test.go
+++ b/oauth_test.go
@@ -244,7 +244,7 @@ func TestViewOauthCallback(t *testing.T) {
 		req, err := http.NewRequest("GET", "/oauth/callback", nil)
 		assert.NoError(t, err)
 		rr := httptest.NewRecorder()
-		err = h.viewOauthCallback(nil, rr, req)
+		err = h.viewOauthCallback(&App{cfg: app.Config(), sessionStore: app.SessionStore()}, rr, req)
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusTemporaryRedirect, rr.Code)
 	})

--- a/parse/posts.go
+++ b/parse/posts.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 A Bunch Tell LLC.
+ * Copyright © 2018-2020 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -53,6 +53,11 @@ func PostLede(t string, includePunc bool) string {
 		t = t[:punc+iAdj]
 	}
 	punc = stringmanip.IndexRune(t, '。')
+	if punc > -1 {
+		c := []rune(t)
+		t = string(c[:punc+iAdj])
+	}
+	punc = stringmanip.IndexRune(t, '?')
 	if punc > -1 {
 		c := []rune(t)
 		t = string(c[:punc+iAdj])


### PR DESCRIPTION
This alters `PostLede` to check for question marks.

Now, `TestPostLede` succeeds, which closes #316. This also fixes a panic in `TestViewOauthCallback`.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
