### PR TITLE
Group variables when applicable to improve readability

### DIFF
--- a/account_import.go
+++ b/account_import.go
@@ -86,9 +86,12 @@ func handleImport(app *App, u *User, w http.ResponseWriter, r *http.Request) err
 		return impart.HTTPError{http.StatusBadRequest, "form data for file dates was invalid"}
 	}
 	files := r.MultipartForm.File["files"]
-	var fileErrs []error
-	filesSubmitted := len(files)
-	var filesImported int
+
+	var (
+		filesImported  int
+		fileErrs       []error
+		filesSubmitted = len(files)
+	)
 	for _, formFile := range files {
 		fname := ""
 		ok := func() bool {

--- a/activitypub.go
+++ b/activitypub.go
@@ -79,8 +79,10 @@ func handleFetchCollectionActivities(app *App, w http.ResponseWriter, r *http.Re
 
 	// TODO: enforce visibility
 	// Get base Collection data
-	var c *Collection
-	var err error
+	var (
+		c   *Collection
+		err error
+	)
 	if app.cfg.App.SingleUser {
 		c, err = app.db.GetCollectionByID(1)
 	} else {
@@ -113,8 +115,10 @@ func handleFetchCollectionOutbox(app *App, w http.ResponseWriter, r *http.Reques
 
 	// TODO: enforce visibility
 	// Get base Collection data
-	var c *Collection
-	var err error
+	var (
+		c   *Collection
+		err error
+	)
 	if app.cfg.App.SingleUser {
 		c, err = app.db.GetCollectionByID(1)
 	} else {
@@ -176,8 +180,10 @@ func handleFetchCollectionFollowers(app *App, w http.ResponseWriter, r *http.Req
 
 	// TODO: enforce visibility
 	// Get base Collection data
-	var c *Collection
-	var err error
+	var (
+		c   *Collection
+		err error
+	)
 	if app.cfg.App.SingleUser {
 		c, err = app.db.GetCollectionByID(1)
 	} else {
@@ -231,8 +237,10 @@ func handleFetchCollectionFollowing(app *App, w http.ResponseWriter, r *http.Req
 
 	// TODO: enforce visibility
 	// Get base Collection data
-	var c *Collection
-	var err error
+	var (
+		c   *Collection
+		err error
+	)
 	if app.cfg.App.SingleUser {
 		c, err = app.db.GetCollectionByID(1)
 	} else {
@@ -273,8 +281,10 @@ func handleFetchCollectionInbox(app *App, w http.ResponseWriter, r *http.Request
 
 	vars := mux.Vars(r)
 	alias := vars["alias"]
-	var c *Collection
-	var err error
+	var (
+		c   *Collection
+		err error
+	)
 	if app.cfg.App.SingleUser {
 		c, err = app.db.GetCollectionByID(1)
 	} else {
@@ -310,10 +320,12 @@ func handleFetchCollectionInbox(app *App, w http.ResponseWriter, r *http.Request
 
 	a := streams.NewAccept()
 	p := c.PersonObject()
-	var to *url.URL
-	var isFollow, isUnfollow bool
-	fullActor := &activitystreams.Person{}
-	var remoteUser *RemoteUser
+	var (
+		to                   *url.URL
+		isFollow, isUnfollow bool
+		fullActor            = &activitystreams.Person{}
+		remoteUser           *RemoteUser
+	)
 
 	res := &streams.Resolver{
 		FollowCallback: func(f *streams.Follow) error {

--- a/admin.go
+++ b/admin.go
@@ -126,6 +126,7 @@ func handleViewAdminDash(app *App, u *User, w http.ResponseWriter, r *http.Reque
 
 	// Get user stats
 	p.UsersCount = app.db.GetAllUsersCount()
+
 	var err error
 	p.CollectionsCount, err = app.db.GetTotalCollections()
 	if err != nil {
@@ -491,8 +492,10 @@ func handleAdminUpdateSite(app *App, u *User, w http.ResponseWriter, r *http.Req
 		return impart.HTTPError{http.StatusNotFound, "No such page."}
 	}
 
-	var err error
-	m := ""
+	var (
+		m   string
+		err error
+	)
 	if id == "landing" {
 		// Handle special landing page
 		err = app.db.UpdateDynamicContent("landing-banner", "", r.FormValue("banner"), "section")

--- a/collections.go
+++ b/collections.go
@@ -345,8 +345,11 @@ func newCollection(app *App, w http.ResponseWriter, r *http.Request) error {
 	alias := r.FormValue("alias")
 	title := r.FormValue("title")
 
-	var missingParams, accessToken string
-	var u *User
+	var (
+		u             *User
+		missingParams string
+		accessToken   string
+	)
 	c := struct {
 		Alias string `json:"alias" schema:"alias"`
 		Title string `json:"title" schema:"title"`
@@ -381,8 +384,10 @@ func newCollection(app *App, w http.ResponseWriter, r *http.Request) error {
 		return impart.HTTPError{http.StatusBadRequest, fmt.Sprintf("Parameter(s) %srequired.", missingParams)}
 	}
 
-	var userID int64
-	var err error
+	var (
+		userID int64
+		err    error
+	)
 	if reqJSON && !c.Web {
 		accessToken = r.Header.Get("Authorization")
 		if accessToken == "" {
@@ -794,6 +799,7 @@ func handleViewCollection(app *App, w http.ResponseWriter, r *http.Request) erro
 	}
 	displayPage.IsAdmin = u != nil && u.IsAdmin()
 	displayPage.CanInvite = canUserInvite(app.cfg, displayPage.IsAdmin)
+
 	var owner *User
 	if u != nil {
 		displayPage.Username = u.Username
@@ -810,6 +816,7 @@ func handleViewCollection(app *App, w http.ResponseWriter, r *http.Request) erro
 			displayPage.Collections = pubColls
 		}
 	}
+
 	isOwner := owner != nil
 	if !isOwner {
 		// Current user doesn't own collection; retrieve owner information
@@ -913,6 +920,7 @@ func handleViewCollectionTag(app *App, w http.ResponseWriter, r *http.Request) e
 		},
 		Tag: tag,
 	}
+
 	var owner *User
 	if u != nil {
 		displayPage.Username = u.Username

--- a/gopher.go
+++ b/gopher.go
@@ -60,10 +60,12 @@ func handleGopher(app *App, w gopher.ResponseWriter, r *gopher.Request) error {
 }
 
 func handleGopherCollection(app *App, w gopher.ResponseWriter, r *gopher.Request) error {
-	var collAlias, slug string
-	var c *Collection
-	var err error
-	var baseSel = "/"
+	var (
+		c               *Collection
+		collAlias, slug string
+		baseSel         = "/"
+		err             error
+	)
 
 	parts := strings.Split(r.Selector, "/")
 	if app.cfg.App.SingleUser {
@@ -108,9 +110,11 @@ func handleGopherCollection(app *App, w gopher.ResponseWriter, r *gopher.Request
 }
 
 func handleGopherCollectionPost(app *App, w gopher.ResponseWriter, r *gopher.Request) error {
-	var collAlias, slug string
-	var c *Collection
-	var err error
+	var (
+		c               *Collection
+		collAlias, slug string
+		err             error
+	)
 
 	parts := strings.Split(r.Selector, "/")
 	if app.cfg.App.SingleUser {


### PR DESCRIPTION
Group variables in all golang files to improve readability. Less words, more space is typically easier on the eyes and brain

---

- [ ] I have signed the [CLA](https://phabricator.write.as/L1)
