### PR TITLE
Adding scope field to generic OAuth

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -108,6 +108,7 @@ type (
 		TokenEndpoint    string `ini:"token_endpoint"`
 		InspectEndpoint  string `ini:"inspect_endpoint"`
 		AuthEndpoint     string `ini:"auth_endpoint"`
+		Scope            string `ini:"scope"`
 		AllowDisconnect  bool   `ini:"allow_disconnect"`
 	}
 

--- a/oauth.go
+++ b/oauth.go
@@ -265,6 +265,7 @@ func configureGenericOauth(parentHandler *Handler, r *mux.Router, app *App) {
 			AuthLocation:     app.Config().GenericOauth.Host + app.Config().GenericOauth.AuthEndpoint,
 			HttpClient:       config.DefaultHTTPClient(),
 			CallbackLocation: callbackLocation,
+			Scope:            config.OrDefaultString(app.Config().GenericOauth.Scope, "read_user"),
 		}
 		configureOauthRoutes(parentHandler, r, app, oauthClient, callbackProxy)
 	}

--- a/oauth_generic.go
+++ b/oauth_generic.go
@@ -15,6 +15,7 @@ type genericOauthClient struct {
 	ExchangeLocation string
 	InspectLocation  string
 	CallbackLocation string
+	Scope            string
 	HttpClient       HttpClient
 }
 
@@ -46,7 +47,7 @@ func (c genericOauthClient) buildLoginURL(state string) (string, error) {
 	q.Set("redirect_uri", c.CallbackLocation)
 	q.Set("response_type", "code")
 	q.Set("state", state)
-	q.Set("scope", "read_user")
+	q.Set("scope", c.Scope)
 	u.RawQuery = q.Encode()
 	return u.String(), nil
 }
@@ -55,7 +56,7 @@ func (c genericOauthClient) exchangeOauthCode(ctx context.Context, code string) 
 	form := url.Values{}
 	form.Add("grant_type", "authorization_code")
 	form.Add("redirect_uri", c.CallbackLocation)
-	form.Add("scope", "read_user")
+	form.Add("scope", c.Scope)
 	form.Add("code", code)
 	req, err := http.NewRequest("POST", c.ExchangeLocation, strings.NewReader(form.Encode()))
 	if err != nil {
@@ -110,5 +111,6 @@ func (c genericOauthClient) inspectOauthAccessToken(ctx context.Context, accessT
 	if inspectResponse.Error != "" {
 		return nil, errors.New(inspectResponse.Error)
 	}
+
 	return &inspectResponse, nil
 }


### PR DESCRIPTION
Some OAuth providers (like Mastodon) do not use the default "read_user" scope, instead offering a set of custom scopes. The config.ini for generic OAuth now contains a "scope" field, allowing the admin to set the scope manually (it defaults to "read_user" if blank).

~I'll have documentation incoming on the documentation repo shortly.~ Documentation PR is up: https://github.com/writefreely/documentation/pull/31

- [X] I have signed the [CLA](https://phabricator.write.as/L1)