### PR TITLE
Generic OAuth userinfo properies now configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -110,6 +110,10 @@ type (
 		AuthEndpoint     string `ini:"auth_endpoint"`
 		Scope            string `ini:"scope"`
 		AllowDisconnect  bool   `ini:"allow_disconnect"`
+		MapUserID        string `ini:"map_user_id"`
+		MapUsername      string `ini:"map_username"`
+		MapDisplayName   string `ini:"map_display_name"`
+		MapEmail         string `ini:"map_email"`
 	}
 
 	// AppCfg holds values that affect how the application functions

--- a/oauth.go
+++ b/oauth.go
@@ -266,6 +266,10 @@ func configureGenericOauth(parentHandler *Handler, r *mux.Router, app *App) {
 			HttpClient:       config.DefaultHTTPClient(),
 			CallbackLocation: callbackLocation,
 			Scope:            config.OrDefaultString(app.Config().GenericOauth.Scope, "read_user"),
+			MapUserID:        config.OrDefaultString(app.Config().GenericOauth.MapUserID, "user_id"),
+			MapUsername:      config.OrDefaultString(app.Config().GenericOauth.MapUsername, "username"),
+			MapDisplayName:   config.OrDefaultString(app.Config().GenericOauth.MapDisplayName, "-"),
+			MapEmail:         config.OrDefaultString(app.Config().GenericOauth.MapEmail, "email"),
 		}
 		configureOauthRoutes(parentHandler, r, app, oauthClient, callbackProxy)
 	}

--- a/oauth_generic.go
+++ b/oauth_generic.go
@@ -16,6 +16,10 @@ type genericOauthClient struct {
 	InspectLocation  string
 	CallbackLocation string
 	Scope            string
+  MapUserID        string
+  MapUsername      string
+  MapDisplayName   string
+  MapEmail         string
 	HttpClient       HttpClient
 }
 
@@ -104,12 +108,28 @@ func (c genericOauthClient) inspectOauthAccessToken(ctx context.Context, accessT
 		return nil, errors.New("unable to inspect access token")
 	}
 
-	var inspectResponse InspectResponse
-	if err := limitedJsonUnmarshal(resp.Body, infoRequestMaxLen, &inspectResponse); err != nil {
+	// since we don't know what the JSON from the server will look like, we create a
+	// generic interface and then map manually to values set in the config
+	var genericInterface interface{}
+	if err := limitedJsonUnmarshal(resp.Body, infoRequestMaxLen, &genericInterface); err != nil {
 		return nil, err
 	}
-	if inspectResponse.Error != "" {
-		return nil, errors.New(inspectResponse.Error)
+
+	m := genericInterface.(map[string]interface{})
+
+	// map each relevant field in inspectResponse to the mapped field from the config
+	var inspectResponse InspectResponse
+	if (m[c.MapUserID] != nil) {
+	  inspectResponse.UserID = m[c.MapUserID].(string)
+	}
+	if (m[c.MapUsername] != nil) {
+	  inspectResponse.Username = m[c.MapUsername].(string)
+	}
+	if (m[c.MapDisplayName] != nil) {
+	  inspectResponse.DisplayName = m[c.MapDisplayName].(string)
+	}
+	if (m[c.MapEmail] != nil) {
+	  inspectResponse.Email = m[c.MapEmail].(string)
 	}
 
 	return &inspectResponse, nil

--- a/oauth_generic.go
+++ b/oauth_generic.go
@@ -16,10 +16,10 @@ type genericOauthClient struct {
 	InspectLocation  string
 	CallbackLocation string
 	Scope            string
-  MapUserID        string
-  MapUsername      string
-  MapDisplayName   string
-  MapEmail         string
+	MapUserID        string
+	MapUsername      string
+	MapDisplayName   string
+	MapEmail         string
 	HttpClient       HttpClient
 }
 
@@ -110,27 +110,17 @@ func (c genericOauthClient) inspectOauthAccessToken(ctx context.Context, accessT
 
 	// since we don't know what the JSON from the server will look like, we create a
 	// generic interface and then map manually to values set in the config
-	var genericInterface interface{}
+	var genericInterface map[string]interface{}
 	if err := limitedJsonUnmarshal(resp.Body, infoRequestMaxLen, &genericInterface); err != nil {
 		return nil, err
 	}
 
-	m := genericInterface.(map[string]interface{})
-
 	// map each relevant field in inspectResponse to the mapped field from the config
 	var inspectResponse InspectResponse
-	if (m[c.MapUserID] != nil) {
-	  inspectResponse.UserID = m[c.MapUserID].(string)
-	}
-	if (m[c.MapUsername] != nil) {
-	  inspectResponse.Username = m[c.MapUsername].(string)
-	}
-	if (m[c.MapDisplayName] != nil) {
-	  inspectResponse.DisplayName = m[c.MapDisplayName].(string)
-	}
-	if (m[c.MapEmail] != nil) {
-	  inspectResponse.Email = m[c.MapEmail].(string)
-	}
+	inspectResponse.UserID, _ = genericInterface[c.MapUserID].(string)
+	inspectResponse.Username, _ = genericInterface[c.MapUsername].(string)
+	inspectResponse.DisplayName, _ = genericInterface[c.MapDisplayName].(string)
+	inspectResponse.Email, _ = genericInterface[c.MapEmail].(string)
 
 	return &inspectResponse, nil
 }


### PR DESCRIPTION
When connecting to a generic OAuth provider, you are never sure what object you'll be receiving from the userinfo endpoint (it isn't actually specified anywhere). So this commit adds mapping values to the generic oauth configuration section of config.ini, allowing the user to specify which keys in the remote endpoint it expects to read the UserID, Username, DisplayName, and Email from. Default values if unspecified remain as they were before this commit.

---

- [X] I have signed the [CLA](https://phabricator.write.as/L1)
