### PR TITLE
Use HTMLContent field in RSS feed

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 A Bunch Tell LLC.
+ * Copyright © 2018-2020 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -104,7 +104,7 @@ func ViewFeed(app *App, w http.ResponseWriter, req *http.Request) error {
 			Title:       title,
 			Link:        &Link{Href: permalink},
 			Description: "<![CDATA[" + stripmd.Strip(p.Content) + "]]>",
-			Content:     applyMarkdown([]byte(p.Content), "", app.cfg),
+			Content:     string(p.HTMLContent),
 			Author:      &Author{author, ""},
 			Created:     p.Created,
 			Updated:     p.Updated,


### PR DESCRIPTION
This re-uses the HTMLContent feed for the full HTML content in the RSS feed, instead of again generating HTML from Markdown.

This keeps things more consistent throughout the application and reduces work when rendering the feed.

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
