### PR TITLE
Case insensitive language highlighting matching

### DIFF
--- a/templates/include/post-render.tmpl
+++ b/templates/include/post-render.tmpl
@@ -68,7 +68,7 @@
       var jss = [hlbaseUri + "highlight.min.js"];
       // Check what we need to load
       for (i=0; i < lb.length; i++) {
-        lang = lb[i].className.replace('language-','');
+        lang = lb[i].className.replace('language-','').toLowerCase();
         // Support the aliases specified above
         if (aliasmap[lang]) lang = aliasmap[lang];
         lurl = hlbaseUri + "highlightjs/" + lang + ".min.js";


### PR DESCRIPTION
This automatically lowercases language names used in code blocks when finding highlighting scripts for them, since highlightJS defines all languages with lowercase names.

This for example allows using `C++` as a language name, which previously would not have worked.

- [Y] I have signed the [CLA](https://phabricator.write.as/L1)
