### PR TITLE
Update writefreely-web image in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ networks:
 services:
   writefreely-web:
     container_name: "writefreely-web"
-    image: "writefreely:latest"
+    image: "writeas/writefreely:latest"
 
     volumes:
       - "web-keys:/go/keys"


### PR DESCRIPTION
Updated with the official writeas/writefreely image on Docker Hub. This prevents the error in #416 from happening.

More than happy to take comments, edits, and other considerations.

---

- [X ] I have signed the [CLA](https://phabricator.write.as/L1)
