### PR TITLE
Add conditional for preserving lang metadata

### DIFF
--- a/templates/pad.tmpl
+++ b/templates/pad.tmpl
@@ -194,8 +194,13 @@
 				body: post.content,
 				title: post.title,
 				font: font,
-				lang: lang
-			};
+			{{ if or .Post.Slug .Post.Id }}
+                        };
+                        {{ else }}
+                                lang: lang
+                        };
+			{{ end }}
+			
 			{{ if .Post.Slug }}
 			var url = "/api/collections/{{.EditCollection.Alias}}/posts/{{.Post.Id}}";
 			{{ else if .Post.Id }}


### PR DESCRIPTION
This PR fixes #280 — if a post is updated, it will retain the language metadata rather than reset back to English.


---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
