### PR TITLE
Post signature improvements

### DIFF
--- a/postrender.go
+++ b/postrender.go
@@ -60,6 +60,10 @@ func (p *PublicPost) formatContent(cfg *config.Config, isOwner bool) {
 }
 
 func (p *Post) augmentContent(c *Collection) {
+	if p.PinnedPosition.Valid {
+		// Don't augment posts that are pinned
+		return
+	}
 	// Add post signatures
 	if c.Signature != "" {
 		p.Content += "\n\n" + c.Signature

--- a/postrender.go
+++ b/postrender.go
@@ -64,6 +64,10 @@ func (p *Post) augmentContent(c *Collection) {
 		// Don't augment posts that are pinned
 		return
 	}
+	if strings.Index(p.Content, "<!--nosig-->") > -1 {
+		// Don't augment posts with the special "nosig" shortcode
+		return
+	}
 	// Add post signatures
 	if c.Signature != "" {
 		p.Content += "\n\n" + c.Signature


### PR DESCRIPTION
This PR makes improvements to Post Signatures, based on several months of use and feedback.

* Hide post signature on pinned posts ([T814](https://phabricator.write.as/T814))
* Support `<!--nosig-->` shortcode to hide the post signature on a post ([T815](https://phabricator.write.as/T815))

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
