### PR TITLE
Fix following from Mastodon with Authorized Fetch enabled

### DIFF
--- a/activitypub.go
+++ b/activitypub.go
@@ -45,12 +45,14 @@ const (
 
 var instanceColl *Collection
 
-func initActivityPub(cfg *config.Config) {
-	ur, _ := url.Parse(cfg.App.Host)
+func initActivityPub(app *App) {
+	ur, _ := url.Parse(app.cfg.App.Host)
 	instanceColl = &Collection{
-		ID:    0,
-		Alias: ur.Host,
-		Title: ur.Host,
+		ID:       0,
+		Alias:    ur.Host,
+		Title:    ur.Host,
+		db:       app.db,
+		hostName: app.cfg.App.Host,
 	}
 }
 

--- a/activitypub.go
+++ b/activitypub.go
@@ -17,7 +17,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/writeas/writefreely/config"
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
@@ -109,15 +108,18 @@ func handleFetchCollectionActivities(app *App, w http.ResponseWriter, r *http.Re
 	if err != nil {
 		return err
 	}
-	silenced, err := app.db.IsUserSilenced(c.OwnerID)
-	if err != nil {
-		log.Error("fetch collection activities: %v", err)
-		return ErrInternalGeneral
-	}
-	if silenced {
-		return ErrCollectionNotFound
-	}
 	c.hostName = app.cfg.App.Host
+
+	if !c.IsInstanceColl() {
+		silenced, err := app.db.IsUserSilenced(c.OwnerID)
+		if err != nil {
+			log.Error("fetch collection activities: %v", err)
+			return ErrInternalGeneral
+		}
+		if silenced {
+			return ErrCollectionNotFound
+		}
+	}
 
 	p := c.PersonObject()
 

--- a/app.go
+++ b/app.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -384,6 +384,8 @@ func Initialize(apper Apper, debug bool) (*App, error) {
 
 	apper.App().InitDecoder()
 
+	apper.App().InitActivityPub()
+
 	err = ConnectToDatabase(apper.App())
 	if err != nil {
 		return nil, fmt.Errorf("connect to DB: %s", err)
@@ -497,6 +499,10 @@ func (app *App) InitDecoder() {
 	app.formDecoder.RegisterConverter(sql.NullBool{}, converter.ConvertSQLNullBool)
 	app.formDecoder.RegisterConverter(sql.NullInt64{}, converter.ConvertSQLNullInt64)
 	app.formDecoder.RegisterConverter(sql.NullFloat64{}, converter.ConvertSQLNullFloat64)
+}
+
+func (app *App) InitActivityPub() {
+	initActivityPub(app.cfg)
 }
 
 // ConnectToDatabase validates and connects to the configured database, then

--- a/app.go
+++ b/app.go
@@ -384,12 +384,12 @@ func Initialize(apper Apper, debug bool) (*App, error) {
 
 	apper.App().InitDecoder()
 
-	apper.App().InitActivityPub()
-
 	err = ConnectToDatabase(apper.App())
 	if err != nil {
 		return nil, fmt.Errorf("connect to DB: %s", err)
 	}
+
+	initActivityPub(apper.App())
 
 	// Handle local timeline, if enabled
 	if apper.App().cfg.App.LocalTimeline {
@@ -499,10 +499,6 @@ func (app *App) InitDecoder() {
 	app.formDecoder.RegisterConverter(sql.NullBool{}, converter.ConvertSQLNullBool)
 	app.formDecoder.RegisterConverter(sql.NullInt64{}, converter.ConvertSQLNullInt64)
 	app.formDecoder.RegisterConverter(sql.NullFloat64{}, converter.ConvertSQLNullFloat64)
-}
-
-func (app *App) InitActivityPub() {
-	initActivityPub(app.cfg)
 }
 
 // ConnectToDatabase validates and connects to the configured database, then

--- a/collections.go
+++ b/collections.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -178,6 +178,11 @@ func (c *Collection) NewFormat() *CollectionFormat {
 	}
 
 	return cf
+}
+
+func (c *Collection) IsInstanceColl() bool {
+	ur, _ := url.Parse(c.hostName)
+	return c.Alias == ur.Host
 }
 
 func (c *Collection) IsUnlisted() bool {

--- a/routes.go
+++ b/routes.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -12,6 +12,7 @@ package writefreely
 
 import (
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -125,9 +126,13 @@ func InitRoutes(apper Apper, r *mux.Router) *mux.Router {
 
 	write.HandleFunc("/api/markdown", handler.All(handleRenderMarkdown)).Methods("POST")
 
+	instanceURL, _ := url.Parse(apper.App().Config().App.Host)
+	host := instanceURL.Host
+
 	// Handle collections
 	write.HandleFunc("/api/collections", handler.All(newCollection)).Methods("POST")
 	apiColls := write.PathPrefix("/api/collections/").Subrouter()
+	apiColls.HandleFunc("/"+host, handler.AllReader(fetchCollection)).Methods("GET")
 	apiColls.HandleFunc("/{alias:[0-9a-zA-Z\\-]+}", handler.AllReader(fetchCollection)).Methods("GET")
 	apiColls.HandleFunc("/{alias:[0-9a-zA-Z\\-]+}", handler.All(existingCollection)).Methods("POST", "DELETE")
 	apiColls.HandleFunc("/{alias}/posts", handler.AllReader(fetchCollectionPosts)).Methods("GET")

--- a/webfinger.go
+++ b/webfinger.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -32,7 +32,9 @@ var wfUserNotFoundErr = impart.HTTPError{http.StatusNotFound, "User not found."}
 func (wfr wfResolver) FindUser(username string, host, requestHost string, r []webfinger.Rel) (*webfinger.Resource, error) {
 	var c *Collection
 	var err error
-	if wfr.cfg.App.SingleUser {
+	if username == host {
+		c = instanceColl
+	} else if wfr.cfg.App.SingleUser {
 		c, err = wfr.db.GetCollectionByID(1)
 	} else {
 		c, err = wfr.db.GetCollection(username)

--- a/webfinger.go
+++ b/webfinger.go
@@ -43,15 +43,18 @@ func (wfr wfResolver) FindUser(username string, host, requestHost string, r []we
 		log.Error("Unable to get blog: %v", err)
 		return nil, err
 	}
-	silenced, err := wfr.db.IsUserSilenced(c.OwnerID)
-	if err != nil {
-		log.Error("webfinger find user: check is silenced: %v", err)
-		return nil, err
-	}
-	if silenced {
-		return nil, wfUserNotFoundErr
-	}
 	c.hostName = wfr.cfg.App.Host
+
+	if !c.IsInstanceColl() {
+		silenced, err := wfr.db.IsUserSilenced(c.OwnerID)
+		if err != nil {
+			log.Error("webfinger find user: check is silenced: %v", err)
+			return nil, err
+		}
+		if silenced {
+			return nil, wfUserNotFoundErr
+		}
+	}
 	if wfr.cfg.App.SingleUser {
 		// Ensure handle matches user-chosen one on single-user blogs
 		if username != c.Alias {


### PR DESCRIPTION
This fixes federation with Mastodon instances that have Authorized Fetch turned on by signing the GET request to fetch the actor when a blog is first followed.

Closes [T820](https://writefreely.org/tasks/820)

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
